### PR TITLE
Add PATCH workout functionality with integration tests

### DIFF
--- a/api/lib/db/queries.dart
+++ b/api/lib/db/queries.dart
@@ -521,8 +521,44 @@ FROM _workout w
 LEFT JOIN _exercises_json ej ON true
 ''';
 
+const _patchWorkout = '''
+WITH _updated AS (
+  UPDATE workouts
+  SET
+    name = coalesce(@name::TEXT, name),
+    started_at = coalesce(@startedAt::TIMESTAMPTZ, started_at),
+    completed_at = coalesce(@completedAt::TIMESTAMPTZ, completed_at)
+  WHERE id = @workoutId::uuid AND user_id = @userId
+  RETURNING id, name, started_at, completed_at, created_at
+)
+SELECT
+  u.id, 
+  u.name, 
+  u.started_at, 
+  u.completed_at, 
+  u.created_at,
+  _workout_exercises(u.id) AS exercises,
+  coalesce(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', wi.id,
+          'key', wi.key, 
+          'workout_id', wi.workout_id
+        ) 
+        ORDER BY wi.id DESC
+      )
+     FROM workout_images wi WHERE wi.workout_id = u.id
+    ),
+    '[]'::jsonb
+  ) AS images
+FROM _updated u
+''';
+
 const _deleteWorkout = '''
-DELETE FROM workouts WHERE id = @workoutId::uuid AND user_id = @userId
+DELETE FROM workouts 
+WHERE id = @workoutId::uuid 
+  AND user_id = @userId
 ''';
 
 const _saveTemplate = '''

--- a/api/lib/db/workouts.dart
+++ b/api/lib/db/workouts.dart
@@ -83,6 +83,29 @@ mixin _Workouts on _DatabaseBase implements ApiWorkoutService {
   }
 
   @override
+  Future<Workout> patchWorkout({
+    required String userId,
+    required String workoutId,
+    required String Function(String) imageUrl,
+    String? name,
+    DateTime? start,
+    DateTime? end,
+  }) async {
+    final rows = await _pool.execute(
+      _patchWorkout.toSql(),
+      parameters: {
+        'workoutId': workoutId,
+        'userId': userId,
+        'name': name,
+        'startedAt': start,
+        'completedAt': end,
+      },
+    );
+    if (rows.isEmpty) throw NotFound(type: 'Workout', id: workoutId);
+    return Workout.fromRow(rows.first.toColumnMap(), imageUrl: imageUrl);
+  }
+
+  @override
   Future<void> deleteWorkout({required String userId, required String workoutId}) async {
     await _pool.execute(
       _deleteWorkout.toSql(),

--- a/api/lib/inputs/inputs.dart
+++ b/api/lib/inputs/inputs.dart
@@ -11,3 +11,4 @@ part 'devices.dart';
 part 'goals.dart';
 part 'pagination.dart';
 part 'parse.dart';
+part 'workouts.dart';

--- a/api/lib/inputs/workouts.dart
+++ b/api/lib/inputs/workouts.dart
@@ -1,0 +1,32 @@
+part of 'inputs.dart';
+
+/// Body for `PATCH /workouts/:workoutId` — a partial update of a workout's own
+/// fields (name, start, end), leaving its exercises untouched. Every field is
+/// optional but at least one must be present; an omitted field is left as-is.
+///
+/// Partial semantics come from omission: a field absent from the body isn't
+/// changed. There's deliberately no way to *clear* a field here (e.g. blank the
+/// name) — an empty/null `name` is rejected rather than treated as a clear.
+class WorkoutPatchIn {
+  final String? name;
+  final DateTime? start;
+  final DateTime? end;
+
+  const WorkoutPatchIn._({this.name, this.start, this.end});
+
+  static Future<WorkoutPatchIn> fromRequest(Request req) async {
+    final json = await req.json();
+    // `string` rejects empty/non-string, so a present `name` is always valid;
+    // absence (not null) is what leaves it unchanged.
+    final name = json.containsKey('name') ? json.string('name') : null;
+    final start = json.dateOrNull('start');
+    final end = json.dateOrNull('end');
+    if (name == null && start == null && end == null) {
+      throw const BadRequest(reason: 'provide at least one of name, start, end');
+    }
+    if (start != null && end != null && end.isBefore(start)) {
+      throw const BadRequest(reason: 'end must not be before start');
+    }
+    return WorkoutPatchIn._(name: name, start: start, end: end);
+  }
+}

--- a/api/lib/models/workouts.dart
+++ b/api/lib/models/workouts.dart
@@ -37,6 +37,18 @@ abstract interface class ApiWorkoutService {
     required String Function(String) imageUrl,
   });
 
+  /// Partial update of a workout the user owns — sets only the provided fields
+  /// (name/start/end), leaving its exercises intact. A null argument leaves that
+  /// field unchanged.
+  Future<Workout> patchWorkout({
+    required String userId,
+    required String workoutId,
+    required String Function(String) imageUrl,
+    String? name,
+    DateTime? start,
+    DateTime? end,
+  });
+
   Future<void> deleteWorkout({
     required String userId,
     required String workoutId,

--- a/api/lib/routes/index.dart
+++ b/api/lib/routes/index.dart
@@ -57,6 +57,7 @@ final routes = <(String, Method), ModelHandler>{
   ('/workouts/images', .get): images.getGallery,
   ('/workouts/:workoutId', .get): workouts.getWorkout,
   ('/workouts/:workoutId', .put): workouts.updateWorkout,
+  ('/workouts/:workoutId', .patch): workouts.patchWorkout,
   ('/workouts/:workoutId', .delete): workouts.deleteWorkout,
   ('/workouts/:workoutId/images', .put): images.presignWorkoutImage,
   ('/workouts/:workoutId/images', .delete): images.deleteWorkoutImage,

--- a/api/lib/routes/workouts.dart
+++ b/api/lib/routes/workouts.dart
@@ -67,6 +67,22 @@ Future<Workout> updateWorkout(final Request request) async {
   );
 }
 
+Future<Workout> patchWorkout(final Request request) {
+  return patchWorkoutById(request, request.rawPathParameters[#workoutId]!);
+}
+
+Future<Workout> patchWorkoutById(final Request request, final String workoutId) async {
+  final input = await WorkoutPatchIn.fromRequest(request);
+  return request.workoutsService.patchWorkout(
+    userId: request.userId,
+    workoutId: workoutId,
+    name: input.name,
+    start: input.start,
+    end: input.end,
+    imageUrl: request.config.cdnAssetUrl,
+  );
+}
+
 Future<NoContent> deleteWorkout(final Request request) async {
   final workoutId = request.pathParameters.raw[#workoutId]!;
   final userId = request.userId;

--- a/api/test/db/workouts_db_test.dart
+++ b/api/test/db/workouts_db_test.dart
@@ -2,13 +2,15 @@
 library;
 
 import 'package:heart/models/errors.dart';
+import 'package:heart/models/workouts.dart';
 import 'package:postgres/postgres.dart' hide Connection;
 import 'package:test/test.dart';
 
 import 'db_test_utility.dart';
 
-/// Exercises the real `patchWorkout` query against a live Postgres: partial
-/// updates of name/start/end, exercises left intact, and owner scoping.
+/// Full integration coverage of the `ApiWorkoutService` query strings against a
+/// live Postgres: create/read/list/update/patch/delete, plus the owner- and
+/// connection-based access rules the SQL encodes.
 ///
 /// Tagged `db` — skipped by the default `dart test` (no database). Run with:
 ///   dart test --run-skipped -t db
@@ -17,49 +19,44 @@ void main() {
 
   final suffix = DateTime.now().microsecondsSinceEpoch.toString();
   final ownerId = 'itest-wk-owner-$suffix';
-  final otherId = 'itest-wk-other-$suffix';
+  final peerId = 'itest-wk-peer-$suffix'; // connected to owner
+  final strangerId = 'itest-wk-stranger-$suffix'; // not connected
+  final listOwnerId = 'itest-wk-list-$suffix'; // isolated, for pagination
   final createdExercises = <String>[];
-  var seedCount = 0;
+  var exCount = 0;
+
   String imageUrl(String key) => 'https://cdn.test/$key';
+  String uniqueExerciseName() => 'ITest WK Ex ${exCount++}-$suffix';
 
   Future<void> exec(String sql, [Map<String, dynamic> params = const {}]) async {
     await harness.pool.execute(Sql.named(sql), parameters: params);
   }
 
-  /// Seeds a completed workout owned by [ownerId] with one exercise + set, and
-  /// returns its id.
-  Future<String> seedWorkout() async {
-    final n = seedCount++;
-    final wk = await harness.pool.execute(
-      Sql.named(
-        'INSERT INTO workouts (user_id, name, started_at, completed_at) '
-        "VALUES (@u, 'Original', @s, @e) RETURNING id",
-      ),
-      parameters: {
-        'u': ownerId,
-        's': DateTime.utc(2026, 7, 20, 18),
-        'e': DateTime.utc(2026, 7, 20, 19),
-      },
-    );
-    final workoutId = wk.first.toColumnMap()['id'].toString();
+  Future<String> insertReturningId(String sql, Map<String, dynamic> params) async {
+    final rows = await harness.pool.execute(Sql.named(sql), parameters: params);
+    return rows.first.toColumnMap()['id'].toString();
+  }
 
-    // Global exercises are unique by name, so vary it per seeded workout.
-    final ex = await harness.pool.execute(
-      Sql.named('INSERT INTO exercises (name, category, target) VALUES (@n, @c, @t) RETURNING id'),
-      parameters: {'n': 'ITest Bench $n-$suffix', 'c': 'Barbell', 't': 'Chest'},
+  Future<String> seedExercise(String name) async {
+    final id = await insertReturningId(
+      'INSERT INTO exercises (name, category, target) VALUES (@n, @c, @t) RETURNING id',
+      {'n': name, 'c': 'Barbell', 't': 'Chest'},
     );
-    final exerciseId = ex.first.toColumnMap()['id'].toString();
-    createdExercises.add(exerciseId);
+    createdExercises.add(id);
+    return id;
+  }
 
-    final we = await harness.pool.execute(
-      Sql.named(
-        'INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order) '
-        'VALUES (@w, @e, 0) RETURNING id',
-      ),
-      parameters: {'w': workoutId, 'e': exerciseId},
+  /// Raw-inserts a workout owned by [userId] with one exercise + one set.
+  Future<String> seedWorkout(String userId, {String name = 'Original', DateTime? start, DateTime? end}) async {
+    final workoutId = await insertReturningId(
+      'INSERT INTO workouts (user_id, name, started_at, completed_at) VALUES (@u, @n, @s, @e) RETURNING id',
+      {'u': userId, 'n': name, 's': start ?? DateTime.utc(2026, 7, 20, 18), 'e': end ?? DateTime.utc(2026, 7, 20, 19)},
     );
-    final weId = we.first.toColumnMap()['id'].toString();
-
+    final exerciseId = await seedExercise(uniqueExerciseName());
+    final weId = await insertReturningId(
+      'INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order) VALUES (@w, @e, 0) RETURNING id',
+      {'w': workoutId, 'e': exerciseId},
+    );
     await exec(
       'INSERT INTO exercise_sets (workout_exercise_id, weight, reps, set_order) VALUES (@we, 100, 5, 0)',
       {'we': weId},
@@ -67,22 +64,50 @@ void main() {
     return workoutId;
   }
 
+  /// A create/update request body referencing [exerciseName] (which must already
+  /// exist so the query can resolve name → id).
+  Map<String, dynamic> reqBody({
+    required String name,
+    required DateTime start,
+    DateTime? end,
+    required String exerciseName,
+  }) {
+    return {
+      'name': name,
+      'start': start.toIso8601String(),
+      if (end != null) 'end': end.toIso8601String(),
+      'exercises': [
+        {
+          'exercise': exerciseName,
+          'order': 0,
+          'sets': [
+            {'weight': 100, 'reps': 5, 'completed': true},
+          ],
+        },
+      ],
+    };
+  }
+
   setUpAll(() async {
     await harness.setupDatabase();
-    for (final id in [ownerId, otherId]) {
+    for (final id in [ownerId, peerId, strangerId, listOwnerId]) {
       await exec('INSERT INTO profiles (id, username, email) VALUES (@id, @u, @e)', {
         'id': id,
         'u': 'wk_${id}_$suffix',
         'e': '$id@test.local',
       });
     }
+    // peer ↔ owner are connected as peers; stranger is left unconnected.
+    await exec(
+      'INSERT INTO connections (initiator_id, target_id, initiator_role, target_role, domain, status) '
+      "VALUES (@p, @o, 'PEER', 'PEER', 'fitness', 'active')",
+      {'p': peerId, 'o': ownerId},
+    );
   });
 
   tearDownAll(() async {
-    // Delete profiles first: workouts/workout_exercises cascade away, freeing
-    // the global exercises (which have no owner to cascade from) to be removed.
     await exec('DELETE FROM profiles WHERE id = ANY(@ids)', {
-      'ids': [ownerId, otherId],
+      'ids': [ownerId, peerId, strangerId, listOwnerId],
     });
     for (final id in createdExercises) {
       await exec('DELETE FROM exercises WHERE id = @id::uuid', {'id': id});
@@ -90,62 +115,250 @@ void main() {
     await harness.teardownDatabase();
   });
 
-  test('updates only the provided fields and preserves exercises', () async {
-    final workoutId = await seedWorkout();
-    final newStart = DateTime.utc(2026, 7, 20, 17, 30);
-    final newEnd = DateTime.utc(2026, 7, 20, 18, 45);
+  group('createWorkout', () {
+    test('persists the workout with its resolved exercise and set', () async {
+      final exName = uniqueExerciseName();
+      await seedExercise(exName);
 
-    final updated = await harness.db.patchWorkout(
-      userId: ownerId,
-      workoutId: workoutId,
-      name: 'Evening push',
-      start: newStart,
-      end: newEnd,
-      imageUrl: imageUrl,
-    );
-
-    expect(updated.name, 'Evening push');
-    expect(updated.start.toUtc(), newStart);
-    expect(updated.end?.toUtc(), newEnd);
-    // The exercise the update didn't touch is still there.
-    expect(updated.length, 1);
-  });
-
-  test('leaves omitted fields unchanged (name-only patch keeps the times)', () async {
-    final workoutId = await seedWorkout();
-
-    final updated = await harness.db.patchWorkout(
-      userId: ownerId,
-      workoutId: workoutId,
-      name: 'Renamed only',
-      start: null,
-      end: null,
-      imageUrl: imageUrl,
-    );
-
-    expect(updated.name, 'Renamed only');
-    expect(updated.start.toUtc(), DateTime.utc(2026, 7, 20, 18)); // original
-    expect(updated.end?.toUtc(), DateTime.utc(2026, 7, 20, 19)); // original
-  });
-
-  test('does not touch a workout owned by someone else', () async {
-    final workoutId = await seedWorkout();
-
-    await expectLater(
-      harness.db.patchWorkout(
-        userId: otherId,
-        workoutId: workoutId,
-        name: 'Hijacked',
-        start: null,
-        end: null,
+      final created = await harness.db.createWorkout(
+        userId: ownerId,
+        body: WorkoutRequest(
+          userId: ownerId,
+          body: reqBody(
+            name: 'New workout',
+            start: DateTime.utc(2026, 7, 25, 10),
+            end: DateTime.utc(2026, 7, 25, 11),
+            exerciseName: exName,
+          ),
+        ),
         imageUrl: imageUrl,
-      ),
-      throwsA(isA<NotFound>()),
-    );
+      );
 
-    // And the owner's copy is untouched.
-    final owned = await harness.db.getWorkout(userId: ownerId, workoutId: workoutId, imageUrl: imageUrl);
-    expect(owned.name, 'Original');
+      expect(created.name, 'New workout');
+      expect(created.start.toUtc(), DateTime.utc(2026, 7, 25, 10));
+      expect(created.end?.toUtc(), DateTime.utc(2026, 7, 25, 11));
+      expect(created.length, 1); // one exercise
+      expect(created.first.exercise.name, exName);
+      expect(created.first.length, 1); // one set
+    });
+  });
+
+  group('getWorkout', () {
+    test('the owner reads their workout with exercises', () async {
+      final id = await seedWorkout(ownerId);
+      final w = await harness.db.getWorkout(userId: ownerId, workoutId: id, imageUrl: imageUrl);
+      expect(w.id, id);
+      expect(w.length, 1);
+    });
+
+    test('another user cannot read it (NotFound)', () async {
+      final id = await seedWorkout(ownerId);
+      await expectLater(
+        harness.db.getWorkout(userId: strangerId, workoutId: id, imageUrl: imageUrl),
+        throwsA(isA<NotFound>()),
+      );
+    });
+  });
+
+  group('getTargetWorkout', () {
+    test('a connected requester reads the target workout', () async {
+      final id = await seedWorkout(ownerId);
+      final w = await harness.db.getTargetWorkout(
+        requesterId: peerId,
+        targetUserId: ownerId,
+        workoutId: id,
+        imageUrl: imageUrl,
+      );
+      expect(w.id, id);
+    });
+
+    test('an unconnected requester is Forbidden', () async {
+      final id = await seedWorkout(ownerId);
+      await expectLater(
+        harness.db.getTargetWorkout(
+          requesterId: strangerId,
+          targetUserId: ownerId,
+          workoutId: id,
+          imageUrl: imageUrl,
+        ),
+        throwsA(isA<Forbidden>()),
+      );
+    });
+
+    test('a connected requester gets NotFound for a missing workout', () async {
+      await expectLater(
+        harness.db.getTargetWorkout(
+          requesterId: peerId,
+          targetUserId: ownerId,
+          workoutId: '00000000-0000-7000-8000-000000000000',
+          imageUrl: imageUrl,
+        ),
+        throwsA(isA<NotFound>()),
+      );
+    });
+  });
+
+  group('getWorkouts', () {
+    test('lists an isolated owner newest-first with limit+1 pagination', () async {
+      final w1 = await seedWorkout(listOwnerId, name: 'W1');
+      final w2 = await seedWorkout(listOwnerId, name: 'W2');
+
+      final page1 = await harness.db.getWorkouts(
+        userId: listOwnerId,
+        targetUserId: listOwnerId,
+        limit: 1,
+        imageUrl: imageUrl,
+      );
+      expect(page1.items, hasLength(1));
+      expect(page1.hasMore, isTrue);
+      expect(page1.items.single.id, w2); // uuidv7 → newest first
+
+      final page2 = await harness.db.getWorkouts(
+        userId: listOwnerId,
+        targetUserId: listOwnerId,
+        cursor: page1.items.single.id,
+        limit: 1,
+        imageUrl: imageUrl,
+      );
+      expect(page2.items.single.id, w1);
+      expect(page2.hasMore, isFalse);
+    });
+
+    test('a connected requester may list the target', () async {
+      await seedWorkout(ownerId);
+      final page = await harness.db.getWorkouts(
+        userId: peerId,
+        targetUserId: ownerId,
+        limit: 10,
+        imageUrl: imageUrl,
+      );
+      expect(page.items, isNotEmpty);
+    });
+
+    test('an unconnected requester is Forbidden', () async {
+      await expectLater(
+        harness.db.getWorkouts(userId: strangerId, targetUserId: ownerId, limit: 10, imageUrl: imageUrl),
+        throwsA(isA<Forbidden>()),
+      );
+    });
+  });
+
+  group('updateWorkout', () {
+    test('replaces the times, name, and exercises', () async {
+      final exA = uniqueExerciseName();
+      await seedExercise(exA);
+      final id = (await harness.db.createWorkout(
+        userId: ownerId,
+        body: WorkoutRequest(
+          userId: ownerId,
+          body: reqBody(name: 'V1', start: DateTime.utc(2026, 7, 25, 8), exerciseName: exA),
+        ),
+        imageUrl: imageUrl,
+      )).id;
+
+      final exB = uniqueExerciseName();
+      await seedExercise(exB);
+      final updated = await harness.db.updateWorkout(
+        userId: ownerId,
+        workoutId: id,
+        body: WorkoutRequest(
+          userId: ownerId,
+          body: reqBody(
+            name: 'V2',
+            start: DateTime.utc(2026, 7, 25, 9),
+            end: DateTime.utc(2026, 7, 25, 10),
+            exerciseName: exB,
+          ),
+        ),
+        imageUrl: imageUrl,
+      );
+
+      expect(updated.name, 'V2');
+      expect(updated.start.toUtc(), DateTime.utc(2026, 7, 25, 9));
+      expect(updated.length, 1);
+      expect(updated.first.exercise.name, exB); // A replaced by B
+    });
+
+    test('updating a workout you do not own throws NotFound', () async {
+      final id = await seedWorkout(ownerId);
+      await expectLater(
+        harness.db.updateWorkout(
+          userId: strangerId,
+          workoutId: id,
+          body: WorkoutRequest(
+            userId: strangerId,
+            body: reqBody(name: 'hijack', start: DateTime.utc(2026, 7, 25, 9), exerciseName: 'nonexistent'),
+          ),
+          imageUrl: imageUrl,
+        ),
+        throwsA(isA<NotFound>()),
+      );
+    });
+  });
+
+  group('deleteWorkout', () {
+    test('the owner deletes their workout', () async {
+      final id = await seedWorkout(ownerId);
+      await harness.db.deleteWorkout(userId: ownerId, workoutId: id);
+      await expectLater(
+        harness.db.getWorkout(userId: ownerId, workoutId: id, imageUrl: imageUrl),
+        throwsA(isA<NotFound>()),
+      );
+    });
+
+    test('deleting a workout you do not own is a no-op', () async {
+      final id = await seedWorkout(ownerId);
+      await harness.db.deleteWorkout(userId: strangerId, workoutId: id);
+      final w = await harness.db.getWorkout(userId: ownerId, workoutId: id, imageUrl: imageUrl);
+      expect(w.id, id); // still there
+    });
+  });
+
+  group('patchWorkout', () {
+    test('updates only the provided fields and preserves exercises', () async {
+      final id = await seedWorkout(ownerId);
+      final newStart = DateTime.utc(2026, 7, 20, 17, 30);
+      final newEnd = DateTime.utc(2026, 7, 20, 18, 45);
+
+      final updated = await harness.db.patchWorkout(
+        userId: ownerId,
+        workoutId: id,
+        name: 'Evening push',
+        start: newStart,
+        end: newEnd,
+        imageUrl: imageUrl,
+      );
+
+      expect(updated.name, 'Evening push');
+      expect(updated.start.toUtc(), newStart);
+      expect(updated.end?.toUtc(), newEnd);
+      expect(updated.length, 1); // exercise untouched
+    });
+
+    test('leaves omitted fields unchanged (name-only patch keeps the times)', () async {
+      final id = await seedWorkout(ownerId);
+
+      final updated = await harness.db.patchWorkout(
+        userId: ownerId,
+        workoutId: id,
+        name: 'Renamed only',
+        imageUrl: imageUrl,
+      );
+
+      expect(updated.name, 'Renamed only');
+      expect(updated.start.toUtc(), DateTime.utc(2026, 7, 20, 18)); // original
+      expect(updated.end?.toUtc(), DateTime.utc(2026, 7, 20, 19)); // original
+    });
+
+    test('does not touch a workout owned by someone else', () async {
+      final id = await seedWorkout(ownerId);
+      await expectLater(
+        harness.db.patchWorkout(userId: strangerId, workoutId: id, name: 'Hijacked', imageUrl: imageUrl),
+        throwsA(isA<NotFound>()),
+      );
+      final owned = await harness.db.getWorkout(userId: ownerId, workoutId: id, imageUrl: imageUrl);
+      expect(owned.name, 'Original');
+    });
   });
 }
 

--- a/api/test/db/workouts_db_test.dart
+++ b/api/test/db/workouts_db_test.dart
@@ -1,0 +1,152 @@
+@Tags(['db'])
+library;
+
+import 'package:heart/models/errors.dart';
+import 'package:postgres/postgres.dart' hide Connection;
+import 'package:test/test.dart';
+
+import 'db_test_utility.dart';
+
+/// Exercises the real `patchWorkout` query against a live Postgres: partial
+/// updates of name/start/end, exercises left intact, and owner scoping.
+///
+/// Tagged `db` — skipped by the default `dart test` (no database). Run with:
+///   dart test --run-skipped -t db
+void main() {
+  final harness = _Harness();
+
+  final suffix = DateTime.now().microsecondsSinceEpoch.toString();
+  final ownerId = 'itest-wk-owner-$suffix';
+  final otherId = 'itest-wk-other-$suffix';
+  final createdExercises = <String>[];
+  var seedCount = 0;
+  String imageUrl(String key) => 'https://cdn.test/$key';
+
+  Future<void> exec(String sql, [Map<String, dynamic> params = const {}]) async {
+    await harness.pool.execute(Sql.named(sql), parameters: params);
+  }
+
+  /// Seeds a completed workout owned by [ownerId] with one exercise + set, and
+  /// returns its id.
+  Future<String> seedWorkout() async {
+    final n = seedCount++;
+    final wk = await harness.pool.execute(
+      Sql.named(
+        'INSERT INTO workouts (user_id, name, started_at, completed_at) '
+        "VALUES (@u, 'Original', @s, @e) RETURNING id",
+      ),
+      parameters: {
+        'u': ownerId,
+        's': DateTime.utc(2026, 7, 20, 18),
+        'e': DateTime.utc(2026, 7, 20, 19),
+      },
+    );
+    final workoutId = wk.first.toColumnMap()['id'].toString();
+
+    // Global exercises are unique by name, so vary it per seeded workout.
+    final ex = await harness.pool.execute(
+      Sql.named('INSERT INTO exercises (name, category, target) VALUES (@n, @c, @t) RETURNING id'),
+      parameters: {'n': 'ITest Bench $n-$suffix', 'c': 'Barbell', 't': 'Chest'},
+    );
+    final exerciseId = ex.first.toColumnMap()['id'].toString();
+    createdExercises.add(exerciseId);
+
+    final we = await harness.pool.execute(
+      Sql.named(
+        'INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order) '
+        'VALUES (@w, @e, 0) RETURNING id',
+      ),
+      parameters: {'w': workoutId, 'e': exerciseId},
+    );
+    final weId = we.first.toColumnMap()['id'].toString();
+
+    await exec(
+      'INSERT INTO exercise_sets (workout_exercise_id, weight, reps, set_order) VALUES (@we, 100, 5, 0)',
+      {'we': weId},
+    );
+    return workoutId;
+  }
+
+  setUpAll(() async {
+    await harness.setupDatabase();
+    for (final id in [ownerId, otherId]) {
+      await exec('INSERT INTO profiles (id, username, email) VALUES (@id, @u, @e)', {
+        'id': id,
+        'u': 'wk_${id}_$suffix',
+        'e': '$id@test.local',
+      });
+    }
+  });
+
+  tearDownAll(() async {
+    // Delete profiles first: workouts/workout_exercises cascade away, freeing
+    // the global exercises (which have no owner to cascade from) to be removed.
+    await exec('DELETE FROM profiles WHERE id = ANY(@ids)', {
+      'ids': [ownerId, otherId],
+    });
+    for (final id in createdExercises) {
+      await exec('DELETE FROM exercises WHERE id = @id::uuid', {'id': id});
+    }
+    await harness.teardownDatabase();
+  });
+
+  test('updates only the provided fields and preserves exercises', () async {
+    final workoutId = await seedWorkout();
+    final newStart = DateTime.utc(2026, 7, 20, 17, 30);
+    final newEnd = DateTime.utc(2026, 7, 20, 18, 45);
+
+    final updated = await harness.db.patchWorkout(
+      userId: ownerId,
+      workoutId: workoutId,
+      name: 'Evening push',
+      start: newStart,
+      end: newEnd,
+      imageUrl: imageUrl,
+    );
+
+    expect(updated.name, 'Evening push');
+    expect(updated.start.toUtc(), newStart);
+    expect(updated.end?.toUtc(), newEnd);
+    // The exercise the update didn't touch is still there.
+    expect(updated.length, 1);
+  });
+
+  test('leaves omitted fields unchanged (name-only patch keeps the times)', () async {
+    final workoutId = await seedWorkout();
+
+    final updated = await harness.db.patchWorkout(
+      userId: ownerId,
+      workoutId: workoutId,
+      name: 'Renamed only',
+      start: null,
+      end: null,
+      imageUrl: imageUrl,
+    );
+
+    expect(updated.name, 'Renamed only');
+    expect(updated.start.toUtc(), DateTime.utc(2026, 7, 20, 18)); // original
+    expect(updated.end?.toUtc(), DateTime.utc(2026, 7, 20, 19)); // original
+  });
+
+  test('does not touch a workout owned by someone else', () async {
+    final workoutId = await seedWorkout();
+
+    await expectLater(
+      harness.db.patchWorkout(
+        userId: otherId,
+        workoutId: workoutId,
+        name: 'Hijacked',
+        start: null,
+        end: null,
+        imageUrl: imageUrl,
+      ),
+      throwsA(isA<NotFound>()),
+    );
+
+    // And the owner's copy is untouched.
+    final owned = await harness.db.getWorkout(userId: ownerId, workoutId: workoutId, imageUrl: imageUrl);
+    expect(owned.name, 'Original');
+  });
+}
+
+class _Harness extends DatabaseTestBase {}

--- a/api/test/routes/workouts_test.dart
+++ b/api/test/routes/workouts_test.dart
@@ -123,4 +123,108 @@ void main() {
       );
     });
   });
+
+  group('patchWorkoutById', () {
+    void stubPatch() {
+      when(
+        workouts.patchWorkout(
+          userId: anyNamed('userId'),
+          workoutId: anyNamed('workoutId'),
+          name: anyNamed('name'),
+          start: anyNamed('start'),
+          end: anyNamed('end'),
+          imageUrl: anyNamed('imageUrl'),
+        ),
+      ).thenAnswer((_) async => _fakeWorkout('w-1'));
+    }
+
+    Request patchReq(Map<String, dynamic> body) =>
+        wire(jsonRequest(method: Method.patch, path: '/workouts/w-1', body: body));
+
+    test('passes the provided fields through to the service', () async {
+      stubPatch();
+      const startIso = '2026-07-20T18:00:00Z';
+      const endIso = '2026-07-20T19:05:00Z';
+
+      final out = await patchWorkoutById(
+        patchReq({'name': 'Evening push', 'start': startIso, 'end': endIso}),
+        'w-1',
+      );
+
+      expect(out.id, 'w-1');
+      verify(
+        workouts.patchWorkout(
+          userId: argThat(equals(_meId), named: 'userId'),
+          workoutId: argThat(equals('w-1'), named: 'workoutId'),
+          name: argThat(equals('Evening push'), named: 'name'),
+          start: argThat(equals(DateTime.parse(startIso)), named: 'start'),
+          end: argThat(equals(DateTime.parse(endIso)), named: 'end'),
+          imageUrl: anyNamed('imageUrl'),
+        ),
+      ).called(1);
+    });
+
+    test('omitted fields arrive as null (left unchanged)', () async {
+      stubPatch();
+
+      await patchWorkoutById(patchReq({'start': '2026-07-20T18:00:00Z'}), 'w-1');
+
+      verify(
+        workouts.patchWorkout(
+          userId: argThat(equals(_meId), named: 'userId'),
+          workoutId: argThat(equals('w-1'), named: 'workoutId'),
+          name: argThat(isNull, named: 'name'),
+          start: argThat(equals(DateTime.parse('2026-07-20T18:00:00Z')), named: 'start'),
+          end: argThat(isNull, named: 'end'),
+          imageUrl: anyNamed('imageUrl'),
+        ),
+      ).called(1);
+    });
+
+    test('rejects an empty body (no fields to change)', () async {
+      await expectLater(patchWorkoutById(patchReq({}), 'w-1'), throwsA(isA<BadRequest>()));
+      verifyNever(
+        workouts.patchWorkout(
+          userId: anyNamed('userId'),
+          workoutId: anyNamed('workoutId'),
+          name: anyNamed('name'),
+          start: anyNamed('start'),
+          end: anyNamed('end'),
+          imageUrl: anyNamed('imageUrl'),
+        ),
+      );
+    });
+
+    test('rejects end before start', () async {
+      await expectLater(
+        patchWorkoutById(
+          patchReq({'start': '2026-07-20T19:00:00Z', 'end': '2026-07-20T18:00:00Z'}),
+          'w-1',
+        ),
+        throwsA(isA<BadRequest>()),
+      );
+    });
+
+    test('rejects a blank name', () async {
+      await expectLater(patchWorkoutById(patchReq({'name': ''}), 'w-1'), throwsA(isA<BadRequest>()));
+    });
+
+    test('propagates NotFound for a workout the user does not own', () async {
+      when(
+        workouts.patchWorkout(
+          userId: anyNamed('userId'),
+          workoutId: anyNamed('workoutId'),
+          name: anyNamed('name'),
+          start: anyNamed('start'),
+          end: anyNamed('end'),
+          imageUrl: anyNamed('imageUrl'),
+        ),
+      ).thenThrow(const NotFound(type: 'Workout', id: 'w-1'));
+
+      await expectLater(
+        patchWorkoutById(patchReq({'name': 'x'}), 'w-1'),
+        throwsA(isA<NotFound>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
### Summary of Changes
- Introduced `WorkoutPatchIn` model for partial workout updates.
- Implemented `patchWorkout` method in the service layer for updating workouts.
- Added `patchWorkout` query in the database layer to handle updates.
- Created a new `PATCH /workouts/:id` route in the workouts API.
- Developed comprehensive database integration tests for the new `patchWorkout` functionality, including specific test cases for the `patchWorkoutById` query.

