### PR TITLE
Update GoalService and WorkoutAggregation features

### DIFF
--- a/api/lib/db/goals.dart
+++ b/api/lib/db/goals.dart
@@ -2,10 +2,14 @@ part of 'db.dart';
 
 mixin _Goals on _DatabaseBase implements GoalService {
   @override
-  Future<Iterable<Goal>> getTargetUserGoals({required String requesterId, required String targetUserId}) async {
+  Future<Iterable<Goal>> getTargetUserGoals({
+    required String requesterId,
+    required String targetUserId,
+    bool archived = false,
+  }) async {
     final rows = await _pool.execute(
       _listTargetGoals.toSql(),
-      parameters: {'requesterId': requesterId, 'targetUserId': targetUserId},
+      parameters: {'requesterId': requesterId, 'targetUserId': targetUserId, 'archived': archived},
     );
     if (rows.isNotEmpty && rows.first.toColumnMap()['forbidden'] == true) {
       throw const Forbidden(reason: 'You do not have permission to view these goals.');

--- a/api/lib/db/goals.dart
+++ b/api/lib/db/goals.dart
@@ -66,7 +66,27 @@ mixin _Goals on _DatabaseBase implements GoalService {
   }
 
   @override
-  Future<Goal> markStageAchieved(String goalId, String stageId, String userId, DateTime achievedAt) async {
+  Future<Goal> markStageAchieved(
+    String goalId,
+    String stageId,
+    String userId,
+    DateTime achievedAt, {
+    String? achievedBy,
+  }) async {
+    // Validated up front, and distinctly from the stage lookup, so an unknown
+    // workout is a 400 rather than getting folded into the stage's 404.
+    if (achievedBy != null) {
+      final owned = await _pool.execute(
+        _workoutOwnedBy.toSql(),
+        parameters: {'workoutId': achievedBy, 'userId': userId},
+      );
+      if (owned.isEmpty) {
+        throw const BadRequest(
+          code: 'goal_workout_unknown',
+          reason: 'achievedBy must be a workout you own',
+        );
+      }
+    }
     final result = await _pool.execute(
       _markStageAchieved.toSql(),
       parameters: {
@@ -74,6 +94,7 @@ mixin _Goals on _DatabaseBase implements GoalService {
         'stageId': stageId,
         'userId': userId,
         'achievedAt': achievedAt.toUtc().toIso8601String(),
+        'achievedBy': achievedBy,
       },
     );
     if (result.isEmpty) throw NotFound(type: 'Goal stage', id: stageId, code: 'goal_stage_not_found');

--- a/api/lib/db/queries.dart
+++ b/api/lib/db/queries.dart
@@ -1417,7 +1417,11 @@ SET stages = jsonb_set(
             WHERE stage ->> 'id' = @stageId
         )],
         (
-            SELECT stage || jsonb_build_object('achievedAt', @achievedAt::text)
+            -- strip_nulls keeps achievedBy out of the blob when it is absent; a
+            -- present value merges (and overwrites) alongside achievedAt.
+            SELECT stage || jsonb_strip_nulls(
+                jsonb_build_object('achievedAt', @achievedAt::text, 'achievedBy', @achievedBy::text)
+            )
             FROM jsonb_array_elements(stages) AS stage
             WHERE stage ->> 'id' = @stageId
         )
@@ -1430,4 +1434,10 @@ WHERE id = @goalId::uuid
       WHERE stage ->> 'id' = @stageId
   )
 RETURNING id, metric, exercise_id, cadence, stages, archived, created_at
+''';
+
+// Guards `achievedBy`: the attributed workout must exist and belong to the caller,
+// checked before the stamp so a bad id is a clean 400 rather than a dangling link.
+const _workoutOwnedBy = '''
+SELECT 1 FROM workouts WHERE id = @workoutId::uuid AND user_id = @userId
 ''';

--- a/api/lib/db/queries.dart
+++ b/api/lib/db/queries.dart
@@ -1362,7 +1362,7 @@ _goals AS (
   FROM goals
   WHERE (SELECT allowed FROM _auth)
     AND user_id = @targetUserId::text
-    AND NOT archived
+    AND archived = @archived::boolean
   ORDER BY created_at
 )
 SELECT id, metric, exercise_id, cadence, stages, archived, created_at, false AS forbidden FROM _goals

--- a/api/lib/inputs/goals.dart
+++ b/api/lib/inputs/goals.dart
@@ -82,15 +82,22 @@ class GoalUpdateIn {
   }
 }
 
-/// `PUT /goals/:goalId/stages/:stageId` — `{achievedAt}`.
+/// `PUT /goals/:goalId/stages/:stageId` — `{achievedAt, achievedBy?}`.
+///
+/// [achievedBy] is the id of the workout the app credits with the rung. It is
+/// optional; when present the db layer checks it is a workout owned by the caller.
 class StageAchievedIn {
   final DateTime achievedAt;
+  final String? achievedBy;
 
-  const StageAchievedIn._({required this.achievedAt});
+  const StageAchievedIn._({required this.achievedAt, this.achievedBy});
 
   static Future<StageAchievedIn> fromRequest(Request req) async {
     final json = await req.json();
-    return StageAchievedIn._(achievedAt: json.timestamp('achievedAt'));
+    return StageAchievedIn._(
+      achievedAt: json.timestamp('achievedAt'),
+      achievedBy: json.stringOrNull('achievedBy'),
+    );
   }
 }
 
@@ -101,7 +108,11 @@ List<GoalStage> _parseStages(Map<String, dynamic> json) {
         id: stage['id'] as String?,
         target: stage.number('target', exclusiveMin: 0),
         dueOn: stage.dateOrNull('dueOn'),
+        // achievedAt and achievedBy both round-trip through the full-replace PUT.
+        // Dropping either here re-blanks stamped rungs (achievedAt did exactly that
+        // once — "goal needs a restart to show Complete"), so both are read back.
         achievedAt: stage.dateOrNull('achievedAt'),
+        achievedBy: stage.stringOrNull('achievedBy'),
       ),
   ];
 }

--- a/api/lib/routes/goals.dart
+++ b/api/lib/routes/goals.dart
@@ -7,13 +7,21 @@ import 'package:relic/relic.dart';
 
 import '../models/errors.dart';
 
-Future<GoalsResponse> getTargetUserGoals(final Request req) =>
-    getTargetUserGoalsById(req, req.rawPathParameters[#targetUserId]!);
+Future<GoalsResponse> getTargetUserGoals(final Request req) => getTargetUserGoalsById(
+  req,
+  req.rawPathParameters[#targetUserId]!,
+  archived: req.queryParameters.raw['archived'] == 'true',
+);
 
-Future<GoalsResponse> getTargetUserGoalsById(final Request req, final String targetUserId) async {
+Future<GoalsResponse> getTargetUserGoalsById(
+  final Request req,
+  final String targetUserId, {
+  final bool archived = false,
+}) async {
   final goals = await req.goalService.getTargetUserGoals(
     requesterId: req.userId,
     targetUserId: targetUserId,
+    archived: archived,
   );
   return GoalsResponse(goals: goals);
 }

--- a/api/lib/routes/goals.dart
+++ b/api/lib/routes/goals.dart
@@ -59,5 +59,11 @@ Future<Goal> markStageAchieved(final Request req) {
 
 Future<Goal> markStageAchievedById(final Request req, final String goalId, final String stageId) async {
   final input = await StageAchievedIn.fromRequest(req);
-  return req.goalService.markStageAchieved(goalId, stageId, req.userId, input.achievedAt);
+  return req.goalService.markStageAchieved(
+    goalId,
+    stageId,
+    req.userId,
+    input.achievedAt,
+    achievedBy: input.achievedBy,
+  );
 }

--- a/api/test/core/app_test.dart
+++ b/api/test/core/app_test.dart
@@ -92,14 +92,33 @@ void main() {
 
     test('a valid token reaches the handler and serializes the result', () async {
       when(
-        db.getTargetUserGoals(requesterId: anyNamed('requesterId'), targetUserId: anyNamed('targetUserId')),
+        db.getTargetUserGoals(
+          requesterId: anyNamed('requesterId'),
+          targetUserId: anyNamed('targetUserId'),
+          archived: anyNamed('archived'),
+        ),
       ).thenAnswer((_) async => const <Goal>[]);
 
       final res = await send('GET', '/accounts/u1/goals', token: 'good');
       expect(res.status, 200);
       expect(jsonDecode(res.body), containsPair('goals', isEmpty));
-      // the authenticated user's id is threaded through as the requester
-      verify(db.getTargetUserGoals(requesterId: 'u1', targetUserId: 'u1')).called(1);
+      // the authenticated user's id is threaded through as the requester, and the
+      // absent query flag defaults to the live slice
+      verify(db.getTargetUserGoals(requesterId: 'u1', targetUserId: 'u1', archived: false)).called(1);
+    });
+
+    test('the ?archived=true query flag reaches the service', () async {
+      when(
+        db.getTargetUserGoals(
+          requesterId: anyNamed('requesterId'),
+          targetUserId: anyNamed('targetUserId'),
+          archived: anyNamed('archived'),
+        ),
+      ).thenAnswer((_) async => const <Goal>[]);
+
+      final res = await send('GET', '/accounts/u1/goals?archived=true', token: 'good');
+      expect(res.status, 200);
+      verify(db.getTargetUserGoals(requesterId: 'u1', targetUserId: 'u1', archived: true)).called(1);
     });
   });
 

--- a/api/test/db/goals_db_test.dart
+++ b/api/test/db/goals_db_test.dart
@@ -81,6 +81,34 @@ void main() {
       expect(visible.map((g) => g.id), contains(created.id));
     });
 
+    test('the archived slice returns only archived goals, never the live ones', () async {
+      final owner = await h.seedProfile();
+      final live = await h.db.createGoal(workoutsGoal(), owner);
+      final done = await h.db.createGoal(workoutsGoal(target: 9), owner);
+      await h.db.updateGoal(done.id!, done.copyWith(archived: true), owner);
+
+      final archived = await h.db.getTargetUserGoals(requesterId: owner, targetUserId: owner, archived: true);
+      expect(archived.map((g) => g.id), contains(done.id));
+      expect(archived.map((g) => g.id), isNot(contains(live.id)));
+      expect(archived.every((g) => g.archived), isTrue);
+    });
+
+    test('connection visibility is identical for the archived slice', () async {
+      final owner = await h.seedProfile();
+      final peer = await h.seedProfile();
+      final outsider = await h.seedProfile();
+      final done = await h.db.createGoal(workoutsGoal(), owner);
+      await h.db.updateGoal(done.id!, done.copyWith(archived: true), owner);
+      await h.seedConnection(initiator: peer, target: owner);
+
+      final visible = await h.db.getTargetUserGoals(requesterId: peer, targetUserId: owner, archived: true);
+      expect(visible.map((g) => g.id), contains(done.id));
+      await expectLater(
+        h.db.getTargetUserGoals(requesterId: outsider, targetUserId: owner, archived: true),
+        throwsA(isA<Forbidden>()),
+      );
+    });
+
     test('a non-connection is forbidden from the owner goals', () async {
       final loner = await h.seedProfile();
       await h.db.createGoal(workoutsGoal(), loner);

--- a/api/test/db/goals_db_test.dart
+++ b/api/test/db/goals_db_test.dart
@@ -263,6 +263,48 @@ void main() {
         throwsA(isA<NotFound>()),
       );
     });
+
+    test('attributes the rung to a workout the caller owns', () async {
+      final workoutId = await h.seedWorkout(userId: ownerId);
+      final at = DateTime.utc(2026, 12, 25, 9);
+      final updated = await h.db.markStageAchieved(goal.id!, firstStageId, ownerId, at, achievedBy: workoutId);
+
+      final first = updated.stages.firstWhere((s) => s.id == firstStageId);
+      expect(first.achievedBy, workoutId);
+      expect(first.achievedAt?.toUtc(), at);
+    });
+
+    test('rejects an achievedBy workout the caller does not own', () async {
+      final strangersWorkout = await h.seedWorkout(userId: strangerId);
+      await expectLater(
+        h.db.markStageAchieved(goal.id!, firstStageId, ownerId, DateTime.utc(2026), achievedBy: strangersWorkout),
+        throwsA(isA<BadRequest>().having((e) => e.code, 'code', 'goal_workout_unknown')),
+      );
+      // and the rung is left unstamped — the guard runs before the write
+      final after = await h.db.getTargetUserGoals(requesterId: ownerId, targetUserId: ownerId);
+      final reread = after.firstWhere((g) => g.id == goal.id).stages.firstWhere((s) => s.id == firstStageId);
+      expect(reread.isAchieved, isFalse);
+    });
+
+    test('a full replace keeps the workout attribution', () async {
+      final workoutId = await h.seedWorkout(userId: ownerId);
+      final stamped = await h.db.markStageAchieved(
+        goal.id!,
+        firstStageId,
+        ownerId,
+        DateTime.utc(2026, 11, 1),
+        achievedBy: workoutId,
+      );
+
+      final edited = await h.db.updateGoal(
+        stamped.id!,
+        stamped.copyWith(stages: [stamped.stages.first, stamped.stages.last.copyWith(target: 130)]),
+        ownerId,
+      );
+
+      final first = edited.stages.firstWhere((s) => s.id == firstStageId);
+      expect(first.achievedBy, workoutId);
+    });
   });
 }
 

--- a/api/test/routes/goals_test.dart
+++ b/api/test/routes/goals_test.dart
@@ -15,6 +15,7 @@ const _otherId = 'u2';
 const _goalId = '019def00-0000-7000-8000-000000000010';
 const _stageId = '019def00-0000-7000-8000-000000000011';
 const _exerciseId = '019def00-0000-7000-8000-000000000001';
+const _workoutId = '019def00-0000-7000-8000-000000000002';
 
 void main() {
   late MockGoalService service;
@@ -258,6 +259,40 @@ void main() {
       verify(service.markStageAchieved(_goalId, _stageId, _meId, achieved)).called(1);
     });
 
+    test('forwards achievedBy to the service', () async {
+      when(
+        service.markStageAchieved(any, any, any, any, achievedBy: anyNamed('achievedBy')),
+      ).thenAnswer(
+        (i) async => Goal(
+          id: _goalId,
+          metric: GoalMetric.topSetWeight,
+          exerciseId: _exerciseId,
+          stages: [
+            GoalStage(
+              id: _stageId,
+              target: 100,
+              achievedAt: i.positionalArguments[3] as DateTime,
+              achievedBy: i.namedArguments[#achievedBy] as String?,
+            ),
+          ],
+        ),
+      );
+
+      final achieved = DateTime.utc(2026, 12, 20, 9, 30);
+      final req = wire(
+        jsonRequest(
+          method: Method.put,
+          path: '/goals/$_goalId/stages/$_stageId',
+          body: {'achievedAt': achieved.toIso8601String(), 'achievedBy': _workoutId},
+        ),
+      );
+
+      final goal = await markStageAchievedById(req, _goalId, _stageId);
+
+      expect(goal.stages.single.achievedBy, _workoutId);
+      verify(service.markStageAchieved(_goalId, _stageId, _meId, achieved, achievedBy: _workoutId)).called(1);
+    });
+
     test('requires achievedAt', () async {
       final req = wire(
         jsonRequest(
@@ -351,6 +386,37 @@ void main() {
       expect(goal.stages.first.achievedAt?.toUtc(), achieved);
       expect(goal.stages.first.isAchieved, isTrue);
       expect(goal.stages.last.achievedAt, isNull, reason: 'the unstamped rung stays unstamped');
+    });
+
+    test('preserves achievedBy through a full replace', () async {
+      // Same regression class as achievedAt: if the input layer drops achievedBy
+      // on the round-trip, a full-replace edit severs the workout attribution.
+      when(service.updateGoal(any, any, any)).thenAnswer((i) async => i.positionalArguments[1] as Goal);
+
+      final req = wire(
+        jsonRequest(
+          method: Method.put,
+          path: '/goals/$_goalId',
+          body: {
+            'metric': 'topSetWeight',
+            'exerciseId': _exerciseId,
+            'stages': [
+              {
+                'id': _stageId,
+                'target': 100,
+                'achievedAt': DateTime.utc(2026, 12, 25, 9).toIso8601String(),
+                'achievedBy': _workoutId,
+              },
+              {'target': 140},
+            ],
+          },
+        ),
+      );
+
+      final goal = await updateGoalById(req, _goalId);
+
+      expect(goal.stages.first.achievedBy, _workoutId);
+      expect(goal.stages.last.achievedBy, isNull, reason: 'the unattributed rung stays unattributed');
     });
   });
 }

--- a/api/test/routes/goals_test.dart
+++ b/api/test/routes/goals_test.dart
@@ -203,6 +203,32 @@ void main() {
 
       await expectLater(() => getTargetUserGoalsById(req, _otherId), throwsA(isA<Forbidden>()));
     });
+
+    test('defaults to the live slice when no flag is passed', () async {
+      when(
+        service.getTargetUserGoals(requesterId: _meId, targetUserId: _otherId, archived: false),
+      ).thenAnswer((_) async => const <Goal>[]);
+
+      final req = wire(bareRequest(method: Method.get, path: '/accounts/$_otherId/goals'));
+      await getTargetUserGoalsById(req, _otherId);
+
+      verify(
+        service.getTargetUserGoals(requesterId: _meId, targetUserId: _otherId, archived: false),
+      ).called(1);
+    });
+
+    test('forwards the archived flag to the service', () async {
+      when(
+        service.getTargetUserGoals(requesterId: _meId, targetUserId: _otherId, archived: true),
+      ).thenAnswer((_) async => const <Goal>[]);
+
+      final req = wire(bareRequest(method: Method.get, path: '/accounts/$_otherId/goals'));
+      await getTargetUserGoalsById(req, _otherId, archived: true);
+
+      verify(
+        service.getTargetUserGoals(requesterId: _meId, targetUserId: _otherId, archived: true),
+      ).called(1);
+    });
   });
 
   group('markStageAchieved', () {

--- a/docs/2026-07-12.goals.md
+++ b/docs/2026-07-12.goals.md
@@ -118,13 +118,27 @@ CREATE INDEX IF NOT EXISTS goals_user_id_idx ON goals (user_id) WHERE NOT archiv
 
 ```json
 [
-  {"id": "0198...", "target": 100, "dueOn": "2026-12-25", "achievedAt": null},
+  {"id": "0198...", "target": 100, "dueOn": "2026-12-25", "achievedAt": "2026-11-02T18:00:00Z", "achievedBy": "0198-workout-uuid"},
   {"id": "0198...", "target": 140, "dueOn": "2027-12-25", "achievedAt": null}
 ]
 ```
 
 Array order **is** ladder order — no `order` field. `id` is a UUID minted by the server on write
-(the app does not need to invent one). `dueOn` and `achievedAt` are both nullable.
+(the app does not need to invent one). `dueOn`, `achievedAt`, and `achievedBy` are all nullable.
+
+`achievedBy` is the id of the **workout** credited with meeting the rung — posterity, and a link the
+client renders from the goal detail back to that session. It attributes to the workout, never a set,
+on purpose: no single set achieves a total-volume or total-reps goal (the whole workout, or the
+week, did), and a set id is a client-minted timestamp (`ExerciseSet` uses `UsesTimestampForId`), so
+a server-owned goal pointing at one would be a dangling cross-device reference. A workout id is a
+server-minted UUID, stable everywhere. Peak metrics (topSetWeight, estimatedOneRepMax,
+maxConsecutiveReps) could additionally carry a set id later; not designed for now. When a rung is
+stamped, the API **validates** `achievedBy` — it must be a workout owned by the achiever, else the
+stamp is a `400` (`goal_workout_unknown`) — so a link that never resolved can't be stored. It does
+**not** clean up after a workout deleted later: `achievedBy` lives inside the JSONB blob with no FK,
+the delete does not cascade, and cleanup wouldn't reach the user's other devices anyway, so the link
+simply goes stale and the client renders it as unavailable. The achievement itself is `achievedAt`,
+which never depends on the workout still existing.
 
 ## 2. heart_models
 
@@ -137,7 +151,8 @@ New `lib/src/models/goal.dart`:
   progress means going *down*, and the app needs to know that to render a ring correctly.
 - `enum GoalCadence { week, month }` with `fromString`.
 - `abstract interface class GoalStage implements Model` — `String id`, `num target`,
-  `DateTime? dueOn`, `DateTime? achievedAt`.
+  `DateTime? dueOn`, `DateTime? achievedAt`, `String? achievedBy` (attributed workout id — see
+  "Stage shape" above for why it's the workout, not the set).
 - `abstract interface class Goal implements Model` — `String id`, `GoalMetric metric`,
   `String? exerciseId`, `GoalCadence? cadence`, `List<GoalStage> stages`, `bool archived`,
   `DateTime createdAt`.
@@ -159,7 +174,9 @@ abstract interface class GoalService {
   Future<Goal> createGoal(Goal goal, String userId);
   Future<Goal> updateGoal(String goalId, Goal goal, String userId);
   Future<void> deleteGoal(String goalId, String userId);
-  Future<Goal> markStageAchieved(String goalId, String stageId, String userId, DateTime achievedAt);
+  // `achievedBy` (optional) credits the workout that met the rung; validated as owned by `userId`.
+  Future<Goal> markStageAchieved(
+    String goalId, String stageId, String userId, DateTime achievedAt, {String? achievedBy});
 }
 ```
 
@@ -182,8 +199,9 @@ Export both from `lib/heart_models.dart`.
 the app must act on. This matters most for `goal_limit`: it's the one rejection a *valid* create
 can hit on server state the app can't see (a goal made on another device, not yet pulled), so the
 app needs to tell it apart from a client-bug 400 or an outage. Goal codes: `goal_limit`,
-`goal_scope`, `goal_cadence_stages`, `goal_not_found`, `goal_stage_not_found`. The code taxonomy is
-general (not goals-only); other routes still emit the category default until they adopt specifics.
+`goal_scope`, `goal_cadence_stages`, `goal_not_found`, `goal_stage_not_found`, `goal_workout_unknown`
+(a stage was stamped with an `achievedBy` that is not a workout the caller owns). The code taxonomy
+is general (not goals-only); other routes still emit the category default until they adopt specifics.
 
 ## 3. api — db layer
 
@@ -207,8 +225,12 @@ SET stages = jsonb_set(
             SELECT (ordinality - 1)::text
             FROM jsonb_array_elements(stages) WITH ORDINALITY AS s(stage, ordinality)
             WHERE stage ->> 'id' = @stageId
-        ), 'achievedAt'],
-        to_jsonb(@achievedAt::text)
+        )],
+        -- merge the stamp onto the whole element; strip_nulls keeps achievedBy out
+        -- of the blob when the rung is unattributed
+        (SELECT stage || jsonb_strip_nulls(
+                 jsonb_build_object('achievedAt', @achievedAt::text, 'achievedBy', @achievedBy::text))
+         FROM jsonb_array_elements(stages) AS stage WHERE stage ->> 'id' = @stageId)
     )
 WHERE id = @goalId::uuid
   AND user_id = @userId
@@ -223,6 +245,12 @@ The `EXISTS` guard matters: without it, an unknown `stageId` makes the `ARRAY[..
 `NULL`, and `jsonb_set` then raises `path element at position 1 is null` — a 500. With the guard,
 no match means zero rows updated ⇒ the route throws `NotFound`. (Verified against PG 18: the
 unguarded query errors rather than corrupting the column, but it is still the wrong response.)
+
+When `achievedBy` is supplied, the db layer first runs `_workoutOwnedBy`
+(`SELECT 1 FROM workouts WHERE id = @workoutId::uuid AND user_id = @userId`) and throws
+`BadRequest(goal_workout_unknown)` on no match — a **separate** step from the stage lookup so an
+unknown workout is a clean `400`, never folded into the stage's `404`. The check is skipped entirely
+when no workout is attributed.
 
 `api/lib/db/goals.dart` — `part of 'db.dart'`; `mixin _Goals on _DatabaseBase implements GoalService`.
 Encode stages with `jsonEncode(goal.stages.map((s) => s.toMap()).toList())`, mint stage ids
@@ -274,17 +302,21 @@ package.
   Cover: create frequency goal (no exercise), create staged strength ladder, reject
   `workouts` + `exerciseId`, reject a per-exercise metric with no `exerciseId`, reject cadence with
   two stages, accept a weaker later milestone (deload ladder), reject `target <= 0`, read a target
-  user's goals + propagate `Forbidden`, mark a stage achieved, 404 on an unknown stage id.
+  user's goals (live + `archived` slice) + propagate `Forbidden`, mark a stage achieved, forward
+  `achievedBy`, 404 on an unknown stage id, and full-replace round-trips of both `achievedAt` and
+  `achievedBy` (regression guards against the input layer silently dropping a stage key).
 - `api/test/db/goals_db_test.dart` (`db` tag) — the query strings against live Postgres, including
   the visibility CTE: owner reads own, an active connection reads the owner's, a non-connection is
-  `Forbidden`, plus owner-scoped writes and the stage-achievement branches.
-- `shared/heart_models/test/goal_test.dart` — `fromJson`/`fromRow`/`toMap` round-trip incl. stages,
-  and `inDeadlineOrder`.
+  `Forbidden`, the archived slice (incl. connection parity), plus owner-scoped writes and the
+  stage-achievement branches — attribution stored, `goal_workout_unknown` on an unowned workout, and
+  attribution surviving a full replace.
+- `shared/heart_models/test/goal_test.dart` — `fromJson`/`fromRow`/`toMap` round-trip incl. stages
+  and `achievedBy`, and `inDeadlineOrder`.
 
 ## Data contract the Flutter app relies on
 
 - `GET /accounts/:targetUserId/goals` → `{"goals": [...]}`, each goal:
-  `{id, metric, exerciseId?, cadence?, stages: [{id, target, dueOn?, achievedAt?}], archived, createdAt}`.
+  `{id, metric, exerciseId?, cadence?, stages: [{id, target, dueOn?, achievedAt?, achievedBy?}], archived, createdAt}`.
   Visible to the owner and to active connections (same auth as `/accounts/:id/workouts`); the app
   reads its **own** goals by passing its own id. A non-connection gets `403 forbidden`.
   - `?archived=true` selects the achieved surface — *only* the archived goals (the flip side of a
@@ -297,8 +329,10 @@ package.
 - `PUT /goals/:goalId` — full replace of the definition + ladder. Stage ids are preserved when the
   client sends them back, minted when absent.
 - `DELETE /goals/:goalId` → 204.
-- `PUT /goals/:goalId/stages/:stageId` `{achievedAt}` → the updated `Goal`. Idempotent: re-sending
-  overwrites the timestamp rather than erroring.
+- `PUT /goals/:goalId/stages/:stageId` `{achievedAt, achievedBy?}` → the updated `Goal`. Idempotent:
+  re-sending overwrites the timestamp rather than erroring. `achievedBy` is an optional workout id
+  crediting the session that met the rung; it must be a workout the caller owns, else
+  `400 {code: goal_workout_unknown}`.
 - Targets are **metric** (kg, km). `metric` values match `ChartPreferenceType` exactly, so the app
   routes each goal to the `heart_db/metrics.dart` query it already has; `workouts` routes to
   `StatsService.getWeeklyWorkoutCount`.

--- a/docs/2026-07-12.goals.md
+++ b/docs/2026-07-12.goals.md
@@ -150,7 +150,12 @@ New `lib/src/services/goals.dart`:
 ```dart
 abstract interface class GoalService {
   // Reads follow the workouts visibility model: owner or an active connection.
-  Future<Iterable<Goal>> getTargetUserGoals({required String requesterId, required String targetUserId});
+  // `archived` picks a slice, never a union: false → live goals, true → the achieved surface.
+  Future<Iterable<Goal>> getTargetUserGoals({
+    required String requesterId,
+    required String targetUserId,
+    bool archived = false,
+  });
   Future<Goal> createGoal(Goal goal, String userId);
   Future<Goal> updateGoal(String goalId, Goal goal, String userId);
   Future<void> deleteGoal(String goalId, String userId);
@@ -184,7 +189,11 @@ general (not goals-only); other routes still emit the category default until the
 
 `api/lib/db/queries.dart` — new `const` SQL strings:
 
-- `_listGoals` — `SELECT ... FROM goals WHERE user_id = @userId AND NOT archived ORDER BY created_at`
+- `_listTargetGoals` — an `_auth` CTE (owner-or-active-connection, mirroring `_listWorkouts`) gates
+  a `_goals` CTE `WHERE ... AND user_id = @targetUserId AND archived = @archived::boolean ORDER BY
+  created_at`; a `UNION ALL` sentinel row (`... true AS forbidden`) fires when auth fails, which the
+  db layer turns into `403`. The `@archived` bind selects the live (`false`) or achieved (`true`)
+  slice — it never widens visibility, which lives entirely in `_auth`.
 - `_createGoal` — `INSERT ... VALUES (@userId, @metric, @exerciseId::uuid, @cadence, @stages::jsonb) RETURNING *`
 - `_updateGoal` — `UPDATE goals SET metric = ..., stages = @stages::jsonb, ... WHERE id = @id::uuid AND user_id = @userId RETURNING *`
 - `_deleteGoal` — `DELETE FROM goals WHERE id = @id::uuid AND user_id = @userId`
@@ -278,6 +287,11 @@ package.
   `{id, metric, exerciseId?, cadence?, stages: [{id, target, dueOn?, achievedAt?}], archived, createdAt}`.
   Visible to the owner and to active connections (same auth as `/accounts/:id/workouts`); the app
   reads its **own** goals by passing its own id. A non-connection gets `403 forbidden`.
+  - `?archived=true` selects the achieved surface — *only* the archived goals (the flip side of a
+    completed card), never a union with the live ones. Default (`false`) returns the live slice
+    that counts against the 50 cap. The flag toggles the slice only; the connection auth is
+    identical either way, so a coach sees a student's achieved goals exactly when they see the
+    live ones. Completing a goal archives it (via `PUT`), which frees a cap slot and moves it here.
 - `POST /goals` `{metric, exerciseId?, cadence?, stages: [{target, dueOn?}]}` → the created `Goal`
   **with server-minted stage ids**.
 - `PUT /goals/:goalId` — full replace of the definition + ladder. Stage ids are preserved when the

--- a/shared/heart_models/CHANGELOG.md
+++ b/shared/heart_models/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+- `GoalService.getTargetUserGoals` gains an optional `archived` flag: `false` (default) returns the
+  live goals, `true` returns only the archived ones — the achieved surface behind a completed card.
+  Additive; existing callers are unaffected.
+
 ## 1.1.0
 
 Changes accumulated on `main` since 1.0.2:

--- a/shared/heart_models/CHANGELOG.md
+++ b/shared/heart_models/CHANGELOG.md
@@ -5,6 +5,9 @@
 - `GoalService.getTargetUserGoals` gains an optional `archived` flag: `false` (default) returns the
   live goals, `true` returns only the archived ones — the achieved surface behind a completed card.
   Additive; existing callers are unaffected.
+- `GoalStage` gains an optional `achievedBy` (workout id crediting the session that met the rung),
+  round-tripped through `fromJson`/`toMap`/`copyWith`. `GoalService.markStageAchieved` takes a
+  matching optional `achievedBy`. Additive; the field is null when unattributed.
 
 ## 1.1.0
 

--- a/shared/heart_models/CHANGELOG.md
+++ b/shared/heart_models/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `GoalStage` gains an optional `achievedBy` (workout id crediting the session that met the rung),
   round-tripped through `fromJson`/`toMap`/`copyWith`. `GoalService.markStageAchieved` takes a
   matching optional `achievedBy`. Additive; the field is null when unattributed.
+- Fix: `WorkoutAggregation` (`fromRows`/`fromJson`) now buckets weeks and anchors the trailing
+  "current week" to the local calendar instead of UTC. West of UTC the old code turned the week over
+  at UTC midnight (an empty week appearing on Sunday evening) and filed a Sunday-night session into
+  the following week.
 
 ## 1.1.0
 

--- a/shared/heart_models/lib/src/models/goal.dart
+++ b/shared/heart_models/lib/src/models/goal.dart
@@ -83,6 +83,20 @@ enum GoalCadence {
 ///
 /// [id] is minted server-side and is stable across reorders — the stage is
 /// addressed by it, never by its position in the array.
+///
+/// [achievedBy] is the id of the workout the app credits with meeting the rung —
+/// posterity, and a link the client renders from the goal back to that session.
+/// It attributes to the *workout*, not a set, deliberately: no single set achieves
+/// a total-volume or total-reps goal (the whole workout, or the week, did), and an
+/// `ExerciseSet` id is a client-minted timestamp (`UsesTimestampForId`), so a
+/// server-owned goal pointing at one would be a dangling cross-device reference. A
+/// workout id is a server-minted UUID, stable everywhere. (Peak metrics —
+/// topSetWeight, estimatedOneRepMax, maxConsecutiveReps — could additionally carry
+/// a set id later if it earns its keep; not designed for now.) The API validates
+/// the id when a rung is stamped: it must be a workout owned by the achiever, or
+/// the stamp is a 400 (`goal_workout_unknown`). That guards against a link that
+/// never resolved; it does not chase a workout deleted afterwards, which the client
+/// tolerates as a stale link.
 abstract interface class GoalStage implements Model {
   String? get id;
 
@@ -92,6 +106,8 @@ abstract interface class GoalStage implements Model {
 
   DateTime? get achievedAt;
 
+  String? get achievedBy;
+
   bool get isAchieved;
 
   factory GoalStage({
@@ -99,6 +115,7 @@ abstract interface class GoalStage implements Model {
     required num target,
     DateTime? dueOn,
     DateTime? achievedAt,
+    String? achievedBy,
   }) = _GoalStage;
 
   /// Parses a stage out of the `stages` JSONB array. Keys are camelCase there —
@@ -121,10 +138,11 @@ abstract interface class GoalStage implements Model {
         final DateTime a => a,
         final other => throw ArgumentError.value(other, 'achievedAt', 'invalid timestamp'),
       },
+      achievedBy: json['achievedBy'] as String?,
     );
   }
 
-  GoalStage copyWith({String? id, num? target, DateTime? dueOn, DateTime? achievedAt});
+  GoalStage copyWith({String? id, num? target, DateTime? dueOn, DateTime? achievedAt, String? achievedBy});
 }
 
 class _GoalStage implements GoalStage {
@@ -136,24 +154,28 @@ class _GoalStage implements GoalStage {
   final DateTime? dueOn;
   @override
   final DateTime? achievedAt;
+  @override
+  final String? achievedBy;
 
   const _GoalStage({
     this.id,
     required this.target,
     this.dueOn,
     this.achievedAt,
+    this.achievedBy,
   });
 
   @override
   bool get isAchieved => achievedAt != null;
 
   @override
-  GoalStage copyWith({String? id, num? target, DateTime? dueOn, DateTime? achievedAt}) {
+  GoalStage copyWith({String? id, num? target, DateTime? dueOn, DateTime? achievedAt, String? achievedBy}) {
     return _GoalStage(
       id: id ?? this.id,
       target: target ?? this.target,
       dueOn: dueOn ?? this.dueOn,
       achievedAt: achievedAt ?? this.achievedAt,
+      achievedBy: achievedBy ?? this.achievedBy,
     );
   }
 
@@ -164,6 +186,7 @@ class _GoalStage implements GoalStage {
       'target': target,
       'dueOn': ?_date(dueOn),
       'achievedAt': ?achievedAt?.toUtc().toIso8601String(),
+      'achievedBy': ?achievedBy,
     };
   }
 

--- a/shared/heart_models/lib/src/models/stats.dart
+++ b/shared/heart_models/lib/src/models/stats.dart
@@ -128,13 +128,17 @@ class _WorkoutAggregation with Iterable<WeekSummary> implements WorkoutAggregati
       },
     ).toList()..sort();
 
-    final currentWeekStart = getMonday(DateTime.timestamp());
+    // Anchor the trailing window to the local "now" so the current week turns over
+    // at local midnight, not at UTC midnight (which shows an empty week early).
+    final currentWeekStart = getMonday(DateTime.now());
 
     if (parsed.isEmpty) {
       return _WorkoutAggregation.empty();
     }
 
-    final earliestParsedWeekStart = parsed.first.startDate.toUtc();
+    // startDate is already a local calendar Monday (getMonday builds an unzoned
+    // DateTime); keep it local so it shares a zone with currentWeekStart below.
+    final earliestParsedWeekStart = parsed.first.startDate;
     final limit = currentWeekStart.subtract(const Duration(days: 7 * 7));
     final earliestWeekStart = switch (earliestParsedWeekStart.isAfter(limit)) {
       true => limit,
@@ -168,7 +172,9 @@ class _WorkoutAggregation with Iterable<WeekSummary> implements WorkoutAggregati
 
     for (final row in rows) {
       final DateTime start = DateTime.parse(row['start']);
-      final String weekId = sanitizeId(getMonday(start));
+      // Bucket by the user's calendar, not UTC: a Sunday-evening session west of
+      // UTC is already Monday in UTC and would file into next week otherwise.
+      final String weekId = sanitizeId(getMonday(start.toLocal()));
 
       byWeek
           .putIfAbsent(weekId, () => [])
@@ -193,8 +199,10 @@ class _WorkoutAggregation with Iterable<WeekSummary> implements WorkoutAggregati
       return _WorkoutAggregation.empty();
     }
 
-    final currentWeekStart = getMonday(DateTime.timestamp());
-    final earliestParsedWeekStart = parsed.first.startDate.toUtc();
+    // Local "now" anchor + a local earliest, matching fromRows — the keys parsed
+    // above were bucketed on the local calendar, so the fill window must be too.
+    final currentWeekStart = getMonday(DateTime.now());
+    final earliestParsedWeekStart = parsed.first.startDate;
     final limit = currentWeekStart.subtract(const Duration(days: 7 * 7));
     final earliestWeekStart = earliestParsedWeekStart.isAfter(limit) ? limit : earliestParsedWeekStart;
 

--- a/shared/heart_models/lib/src/services/goals.dart
+++ b/shared/heart_models/lib/src/services/goals.dart
@@ -23,5 +23,14 @@ abstract interface class GoalService {
 
   /// Stamps a single stage as achieved, leaving the rest of the ladder intact.
   /// Idempotent — re-sending overwrites the timestamp rather than failing.
-  Future<Goal> markStageAchieved(String goalId, String stageId, String userId, DateTime achievedAt);
+  ///
+  /// [achievedBy], when given, credits the workout that met the rung (a link the
+  /// client renders). It must be a workout owned by [userId], else `BadRequest`.
+  Future<Goal> markStageAchieved(
+    String goalId,
+    String stageId,
+    String userId,
+    DateTime achievedAt, {
+    String? achievedBy,
+  });
 }

--- a/shared/heart_models/lib/src/services/goals.dart
+++ b/shared/heart_models/lib/src/services/goals.dart
@@ -4,8 +4,16 @@ abstract interface class GoalService {
   /// Goals a user has, visible to the owner and to their active connections —
   /// the same read model as workouts. [requesterId] must be [targetUserId] or an
   /// active COACH/PEER of them, or this throws `Forbidden`. Writing stays
-  /// owner-only. Archived goals are excluded.
-  Future<Iterable<Goal>> getTargetUserGoals({required String requesterId, required String targetUserId});
+  /// owner-only.
+  ///
+  /// [archived] selects which slice, never a union: the default `false` returns
+  /// the live goals (those counting against the cap), `true` returns *only* the
+  /// archived ones — the "achieved" surface behind a completed goal's card.
+  Future<Iterable<Goal>> getTargetUserGoals({
+    required String requesterId,
+    required String targetUserId,
+    bool archived = false,
+  });
 
   Future<Goal> createGoal(Goal goal, String userId);
 

--- a/shared/heart_models/pubspec.yaml
+++ b/shared/heart_models/pubspec.yaml
@@ -1,6 +1,6 @@
 name: heart_models
 description: "Interfaces and data classes"
-version: 1.1.0
+version: 1.2.0
 publish_to: none
 
 environment:

--- a/shared/heart_models/test/goal_test.dart
+++ b/shared/heart_models/test/goal_test.dart
@@ -44,6 +44,27 @@ void main() {
       expect(GoalStage(target: 100).isAchieved, isFalse);
       expect(GoalStage(target: 100, achievedAt: DateTime.utc(2026, 7, 1)).isAchieved, isTrue);
     });
+
+    test('round-trips achievedBy through toMap/fromJson', () {
+      final stage = GoalStage(
+        id: 's-1',
+        target: 100,
+        achievedAt: DateTime.utc(2026, 7, 1),
+        achievedBy: 'w-42',
+      );
+      final parsed = GoalStage.fromJson(stage.toMap());
+      expect(parsed.achievedBy, 'w-42');
+      expect(parsed.achievedAt, DateTime.utc(2026, 7, 1));
+    });
+
+    test('omits achievedBy when the rung is unattributed', () {
+      expect(GoalStage(target: 100, achievedAt: DateTime.utc(2026, 7, 1)).toMap().containsKey('achievedBy'), isFalse);
+    });
+
+    test('copyWith carries achievedBy', () {
+      final stage = GoalStage(target: 100, achievedBy: 'w-1');
+      expect(stage.copyWith(target: 120).achievedBy, 'w-1');
+    });
   });
 
   group('Goal', () {

--- a/shared/heart_models/test/stats_test.dart
+++ b/shared/heart_models/test/stats_test.dart
@@ -34,4 +34,44 @@ void main() {
       );
     },
   );
+
+  group('WorkoutAggregation.fromRows bucketing', () {
+    List<WeekSummary> nonEmptyWeeks(WorkoutAggregation agg) => agg.where((week) => week.isNotEmpty).toList();
+
+    test('buckets by the local calendar week, not UTC', () {
+      // These UTC instants read as Sunday 23:30 and Monday-of-the-same-week noon
+      // on the *local* clock. West of UTC the Sunday-night instant is already
+      // Monday in UTC, which is exactly when the old UTC bucketing filed it into
+      // the next week and split the two apart. On the local calendar they share a
+      // Mon–Sun week, so a correct bucketing groups them. (Aug 3 2026 is a Monday,
+      // Aug 9 the Sunday that closes its week.) In a UTC test environment the two
+      // clocks coincide and this still passes; in any western zone it fails on the
+      // pre-fix code — the regression guard the UTC anchoring lacked.
+      final localSundayNight = DateTime(2026, 8, 9, 23, 30);
+      final localWeekMonday = DateTime(2026, 8, 3, 12);
+
+      final agg = WorkoutAggregation.fromRows([
+        {'id': 'w-sun', 'name': 'Sunday', 'start': localSundayNight.toUtc().toIso8601String()},
+        {'id': 'w-mon', 'name': 'Monday', 'start': localWeekMonday.toUtc().toIso8601String()},
+      ]);
+
+      final weeks = nonEmptyWeeks(agg);
+      expect(weeks, hasLength(1), reason: 'both sessions fall in one local week');
+      expect(weeks.single, hasLength(2));
+    });
+
+    test('files sessions from different weeks into separate buckets', () {
+      final firstWeek = DateTime(2026, 8, 4, 10); // week of Mon Aug 3
+      final secondWeek = DateTime(2026, 8, 11, 10); // week of Mon Aug 10
+
+      final agg = WorkoutAggregation.fromRows([
+        {'id': 'a', 'name': 'A', 'start': firstWeek.toUtc().toIso8601String()},
+        {'id': 'b', 'name': 'B', 'start': secondWeek.toUtc().toIso8601String()},
+      ]);
+
+      final weeks = nonEmptyWeeks(agg);
+      expect(weeks, hasLength(2));
+      expect(weeks.every((w) => w.length == 1), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
### Description of Changes

This pull request includes the following changes:

- **WorkoutAggregation**: Updated bucketing logic to use local calendar weeks instead of UTC.
- **GoalService**:
  - Added `achievedBy` validation in API and service with full-replace support.
  - Introduced `achievedBy` attribution field in GoalStage and GoalService.
  - Extended `archived` flag behavior in API endpoints and GoalService.
  - Made the `archived` flag optional for `GoalService.getTargetUserGoals`.
