### PR TITLE
Add bulk workout import from Strong CSV exports

### DIFF
--- a/api/lib/core/request.dart
+++ b/api/lib/core/request.dart
@@ -13,6 +13,11 @@ extension JsonBody on Request {
     };
   }
 
+  /// Raw text body, whatever the declared content type — file uploads like a
+  /// CSV export arrive as `text/csv`, `text/plain`, or `application/octet-stream`
+  /// depending on the client, and the parser is the real gatekeeper anyway.
+  Future<String> text() => readAsString();
+
   /// reproducible raw shape of the request
   Map<String, String> signature() {
     return {

--- a/api/lib/db/db.dart
+++ b/api/lib/db/db.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'package:heart/models/errors.dart';
 import 'package:heart/models/exercises.dart';
 import 'package:heart/models/images.dart';
+import 'package:heart/models/imports.dart';
 import 'package:heart/models/profile.dart';
 import 'package:heart/models/workouts.dart';
 import 'package:heart_models/heart_models.dart' hide WorkoutService, TemplateService, ExerciseService;

--- a/api/lib/db/queries.dart
+++ b/api/lib/db/queries.dart
@@ -463,6 +463,87 @@ LEFT JOIN _exercises_json ej
   ON true
 ''';
 
+/// Whole CSV import in one atomic statement. Unlike [_saveWorkout]'s lookup —
+/// which silently drops exercises it can't resolve — unknown names are first
+/// created as the user's custom exercises, so nothing in the export vanishes.
+/// Workouts land with ON CONFLICT DO NOTHING on (user_id, import_id): re-running
+/// the same export inserts nothing and the report shows it.
+const _importWorkouts = '''
+WITH
+_incoming AS (
+  SELECT w AS workout, w->>'importId' AS import_id
+  FROM jsonb_array_elements(@workouts::jsonb) w
+),
+_names AS (
+  SELECT ex->>'name' AS name, ex->>'category' AS category, ex->>'target' AS target
+  FROM jsonb_array_elements(@exercises::jsonb) ex
+),
+_resolved AS (
+  SELECT DISTINCT ON (e.name) e.name, e.id
+  FROM exercises e
+  JOIN _names n ON n.name = e.name
+  WHERE e.user_id IS NULL OR e.user_id = @userId
+  ORDER BY e.name, e.user_id NULLS LAST
+),
+_created_exercises AS (
+  INSERT INTO exercises (name, category, target, user_id)
+  SELECT n.name, n.category, n.target, @userId
+  FROM _names n
+  WHERE NOT EXISTS (SELECT 1 FROM _resolved r WHERE r.name = n.name)
+  RETURNING id, name
+),
+_lookup AS (
+  SELECT name, id FROM _resolved
+  UNION ALL
+  SELECT name, id FROM _created_exercises
+),
+_inserted_workouts AS (
+  INSERT INTO workouts (user_id, name, started_at, completed_at, import_id)
+  SELECT @userId, NULLIF(i.workout->>'name', ''), (i.workout->>'start')::timestamptz, (i.workout->>'end')::timestamptz, i.import_id
+  FROM _incoming i
+  ON CONFLICT (user_id, import_id) WHERE import_id IS NOT NULL DO NOTHING
+  RETURNING id, import_id
+),
+_exercises_in AS (
+  SELECT iw.id AS workout_id, ex AS exercise, (ex->>'order')::int AS exercise_order
+  FROM _inserted_workouts iw
+  JOIN _incoming i ON i.import_id = iw.import_id
+  CROSS JOIN LATERAL jsonb_array_elements(i.workout->'exercises') ex
+),
+_inserted_exercises AS (
+  INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order)
+  SELECT e.workout_id, l.id, e.exercise_order
+  FROM _exercises_in e
+  JOIN _lookup l ON l.name = e.exercise->>'name'
+  RETURNING id, workout_id, exercise_order
+),
+_sets_in AS (
+  SELECT e.workout_id, e.exercise_order, t.s AS set_data, (t.ordinality - 1)::int AS set_order
+  FROM _exercises_in e
+  CROSS JOIN LATERAL jsonb_array_elements(e.exercise->'sets') WITH ORDINALITY t(s, ordinality)
+),
+_inserted_sets AS (
+  INSERT INTO exercise_sets (workout_exercise_id, weight, reps, duration, distance, completed, set_order)
+  SELECT
+    ie.id,
+    (si.set_data->>'weight')::real,
+    (si.set_data->>'reps')::int,
+    (si.set_data->>'duration')::int,
+    (si.set_data->>'distance')::real,
+    true,
+    si.set_order
+  FROM _sets_in si
+  JOIN _inserted_exercises ie ON ie.workout_id = si.workout_id AND ie.exercise_order = si.exercise_order
+  RETURNING id
+)
+SELECT
+  (SELECT count(*) FROM _incoming)::int AS workouts_found,
+  (SELECT count(*) FROM _inserted_workouts)::int AS workouts_created,
+  (SELECT count(*) FROM _inserted_sets)::int AS sets_created,
+  (SELECT count(*) FROM _resolved)::int AS exercises_matched,
+  COALESCE((SELECT jsonb_agg(name ORDER BY name) FROM _created_exercises), '[]'::jsonb) AS exercises_created
+''';
+
 const _replaceWorkout = '''
 WITH
 _order_to_name AS (

--- a/api/lib/db/workouts.dart
+++ b/api/lib/db/workouts.dart
@@ -108,6 +108,19 @@ mixin _Workouts on _DatabaseBase implements ApiWorkoutService {
   }
 
   @override
+  Future<WorkoutImportReport> importWorkouts({required String userId, required WorkoutImport batch}) async {
+    final rows = await _pool.execute(
+      _importWorkouts.toSql(),
+      parameters: batch.toParams(userId: userId),
+    );
+    return WorkoutImportReport.fromRow(
+      rows.first.toColumnMap(),
+      source: batch.source,
+      rowsSkipped: batch.rowsSkipped,
+    );
+  }
+
+  @override
   Future<void> deleteWorkout({required String userId, required String workoutId}) async {
     await _pool.execute(
       _deleteWorkout.toSql(),

--- a/api/lib/inputs/inputs.dart
+++ b/api/lib/inputs/inputs.dart
@@ -6,6 +6,7 @@ import 'package:heart/core/request.dart';
 import 'package:heart/globals/config.dart';
 import 'package:heart/globals/globals.dart';
 import 'package:heart/models/errors.dart';
+import 'package:heart/models/imports.dart';
 import 'package:heart_models/heart_models.dart';
 import 'package:mime/mime.dart';
 import 'package:relic/relic.dart';

--- a/api/lib/inputs/workouts.dart
+++ b/api/lib/inputs/workouts.dart
@@ -12,6 +12,51 @@ part of 'inputs.dart';
 /// `calories` exists on PATCH because wearable energy totals settle after the
 /// workout is saved: HealthKit delivers the final active-energy figure minutes
 /// later, and the device patches it in once known.
+/// `POST /workouts/imports?source=strong` — a raw CSV export in the body,
+/// parsed and unit-normalized here so the route layer only ever sees the
+/// canonical [WorkoutImport] batch.
+///
+/// Query params:
+/// - `source` (required): the exporting app; only `strong` so far.
+/// - `unit` (optional, `metric`|`imperial`, default `metric`): fallback for
+///   exports that carry no unit columns of their own.
+/// - `tzOffset` (optional, `±HH:MM`): the exporting device's UTC offset —
+///   Strong timestamps are naive local time.
+class ImportWorkoutsIn {
+  final WorkoutImport batch;
+
+  const ImportWorkoutsIn._(this.batch);
+
+  static Future<ImportWorkoutsIn> fromRequest(Request req) async {
+    final q = req.url.queryParameters;
+    final source = q.string('source');
+    if (source != 'strong') {
+      throw BadRequest(reason: 'unsupported source: $source (supported: strong)');
+    }
+    final unit = switch (q.stringOrNull('unit')) {
+      null => MeasurementUnit.metric,
+      _ => q.parsed('unit', MeasurementUnit.fromString),
+    };
+    final offset = switch (q.stringOrNull('tzOffset')) {
+      null => Duration.zero,
+      _ => q.parsed('tzOffset', _tzOffset),
+    };
+    final csv = await req.text();
+    try {
+      return ImportWorkoutsIn._(WorkoutImport.fromStrongCsv(csv, unit: unit, utcOffset: offset));
+    } on FormatException catch (e) {
+      throw BadRequest(reason: 'not a readable Strong export: ${e.message}');
+    }
+  }
+
+  static Duration _tzOffset(String raw) {
+    final match = RegExp(r'^([+-])(\d{2}):(\d{2})$').firstMatch(raw);
+    if (match == null) throw const FormatException();
+    final offset = Duration(hours: int.parse(match.group(2)!), minutes: int.parse(match.group(3)!));
+    return match.group(1) == '-' ? -offset : offset;
+  }
+}
+
 class WorkoutPatchIn {
   final String? name;
   final DateTime? start;

--- a/api/lib/models/imports.dart
+++ b/api/lib/models/imports.dart
@@ -1,0 +1,437 @@
+import 'dart:convert';
+
+import 'package:heart_models/heart_models.dart';
+
+/// Bulk workout import from another app's CSV export.
+///
+/// The parser turns a one-row-per-set export into the canonical
+/// workout/exercise/set shape; the DB layer writes it in a single statement.
+/// Each workout carries a deterministic [ImportedWorkout.importId] derived
+/// from the source row, so re-running the same export is a no-op rather than
+/// a duplicate history.
+
+/// A parsed, unit-normalized import batch, ready for the DB layer.
+///
+/// Measurements are canonical metric (kg, km, seconds) regardless of the
+/// export's display unit — matching what the client stores.
+class WorkoutImport {
+  final String source;
+  final List<ImportedWorkout> workouts;
+
+  /// Data rows that failed to parse and were left out of the batch.
+  final int rowsSkipped;
+
+  WorkoutImport._({required this.source, required this.workouts, required this.rowsSkipped});
+
+  /// Distinct exercise names across the batch, each with a category/target
+  /// guess for the ones that turn out not to exist and need to be created as
+  /// the user's custom exercises.
+  List<Map<String, String>> get exercises {
+    final shapes = <String, ({bool weight, bool distance, bool seconds})>{};
+    for (final workout in workouts) {
+      for (final exercise in workout.exercises) {
+        final prior = shapes[exercise.name] ?? (weight: false, distance: false, seconds: false);
+        shapes[exercise.name] = (
+          weight: prior.weight || exercise.sets.any((s) => s.weight != null),
+          distance: prior.distance || exercise.sets.any((s) => s.distance != null),
+          seconds: prior.seconds || exercise.sets.any((s) => s.duration != null),
+        );
+      }
+    }
+    return [
+      for (final MapEntry(key: name, value: shape) in shapes.entries)
+        {'name': name, 'category': _category(name, shape), 'target': 'Other'},
+    ];
+  }
+
+  Map<String, dynamic> toParams({required String userId}) {
+    return {
+      'userId': userId,
+      'workouts': jsonEncode([for (final w in workouts) w.toPayload()]),
+      'exercises': jsonEncode(exercises),
+    };
+  }
+
+  /// Parses a Strong CSV export (one row per set).
+  ///
+  /// Columns are matched by normalized header name, so the several column
+  /// layouts Strong has shipped all parse: `Weight`+`Weight Unit`,
+  /// `Weight (kg)`, `Distance (meters)`, `Workout Duration` vs `Duration`, and
+  /// both `,` and `;` delimiters. [unit] is the fallback for exports that
+  /// carry no unit information at all. Strong timestamps are naive local
+  /// time; [utcOffset] is the exporting device's offset, applied to pin them
+  /// to instants.
+  ///
+  /// Throws [FormatException] when the text isn't recognizable as a Strong
+  /// export; individual bad rows are skipped and counted instead.
+  factory WorkoutImport.fromStrongCsv(
+    String csv, {
+    MeasurementUnit unit = MeasurementUnit.metric,
+    Duration utcOffset = Duration.zero,
+  }) {
+    final delimiter = _detectDelimiter(csv);
+    final rows = parseCsv(csv, delimiter: delimiter);
+    if (rows.isEmpty) throw const FormatException('empty file');
+
+    final header = [for (final cell in rows.first) _normalized(cell)];
+    int? column(List<String> candidates) {
+      for (final c in candidates) {
+        final i = header.indexOf(c);
+        if (i != -1) return i;
+      }
+      return null;
+    }
+
+    final date = column(['date']);
+    final workoutName = column(['workoutname']);
+    final exerciseName = column(['exercisename']);
+    if (date == null || workoutName == null || exerciseName == null) {
+      throw const FormatException('expected Strong columns: Date, Workout Name, Exercise Name');
+    }
+    final duration = column(['duration', 'workoutduration']);
+    final weight = column(['weight', 'weightkg', 'weightlbs', 'weightlb']);
+    final weightUnit = column(['weightunit']);
+    final reps = column(['reps']);
+    final distance = column(['distance', 'distancemeters', 'distancekm', 'distancemiles']);
+    final distanceUnit = column(['distanceunit']);
+    final seconds = column(['seconds']);
+
+    // a unit spelled out in the header itself ("Weight (kg)") beats the fallback
+    final headerWeightUnit = weight == null ? null : _unitIn(header[weight]);
+    final headerDistanceUnit = distance == null ? null : _unitIn(header[distance]);
+
+    String? cell(List<String> row, int? index) {
+      if (index == null || index >= row.length) return null;
+      final v = row[index].trim();
+      return v.isEmpty ? null : v;
+    }
+
+    // Strong writes runaway durations with an unquoted thousands separator
+    // ("3,527h 3min"), splitting the field and shifting the row; merging the
+    // two pieces back restores the column alignment.
+    List<String> repaired(List<String> row) {
+      if (duration == null || row.length <= header.length) return row;
+      final merged = '${row[duration]},${row[duration + 1]}';
+      if (!RegExp(r'^\d{1,3}(,\d{3})+h( \d+(m|min))?$').hasMatch(merged)) return row;
+      return [...row.sublist(0, duration), merged, ...row.sublist(duration + 2)];
+    }
+
+    var skipped = 0;
+    final builders = <String, _WorkoutBuilder>{};
+    for (final row in rows.skip(1).map(repaired)) {
+      try {
+        final rawDate = cell(row, date) ?? (throw const FormatException('no date'));
+        final exercise = cell(row, exerciseName) ?? (throw const FormatException('no exercise'));
+        final name = cell(row, workoutName);
+        // parse the entire row before touching the builders, so a bad row
+        // can't leave a half-built workout behind
+        final set = ImportedSet(
+          weight: _toKilograms(_number(cell(row, weight)), cell(row, weightUnit) ?? headerWeightUnit, unit),
+          reps: _count(cell(row, reps)),
+          duration: _count(cell(row, seconds)),
+          distance: _toKilometers(_number(cell(row, distance)), cell(row, distanceUnit) ?? headerDistanceUnit, unit),
+        );
+        final builder = builders.putIfAbsent('$rawDate $name', () {
+          final start = _instant(rawDate, utcOffset);
+          return _WorkoutBuilder(
+            importId: 'strong:$rawDate#${name ?? ''}',
+            name: name,
+            start: start,
+            // a "duration" past 24h is a workout left running, not a window
+            // worth storing
+            end: switch (_parseDuration(cell(row, duration))) {
+              Duration d when d > Duration.zero && d <= const Duration(hours: 24) => start.add(d),
+              _ => null,
+            },
+          );
+        });
+        builder.exercise(exercise).add(set);
+      } on FormatException {
+        skipped++;
+      }
+    }
+    return WorkoutImport._(
+      source: 'strong',
+      workouts: [for (final b in builders.values) b.build()],
+      rowsSkipped: skipped,
+    );
+  }
+}
+
+class ImportedWorkout {
+  final String importId;
+  final String? name;
+  final DateTime start;
+  final DateTime? end;
+  final List<ImportedExercise> exercises;
+
+  const ImportedWorkout({
+    required this.importId,
+    required this.name,
+    required this.start,
+    required this.end,
+    required this.exercises,
+  });
+
+  Map<String, dynamic> toPayload() {
+    return {
+      'importId': importId,
+      'name': ?name,
+      'start': start.toIso8601String(),
+      'end': ?end?.toIso8601String(),
+      'exercises': [
+        for (final (order, exercise) in exercises.indexed)
+          {
+            'name': exercise.name,
+            'order': order,
+            'sets': [for (final set in exercise.sets) set.toPayload()],
+          },
+      ],
+    };
+  }
+}
+
+class ImportedExercise {
+  final String name;
+  final List<ImportedSet> sets;
+
+  const ImportedExercise({required this.name, required this.sets});
+}
+
+class ImportedSet {
+  final double? weight;
+  final int? reps;
+  final int? duration;
+  final double? distance;
+
+  const ImportedSet({this.weight, this.reps, this.duration, this.distance});
+
+  Map<String, dynamic> toPayload() {
+    return {'weight': ?weight, 'reps': ?reps, 'duration': ?duration, 'distance': ?distance};
+  }
+}
+
+/// What the import did, returned as the endpoint's response body.
+class WorkoutImportReport implements Model {
+  final String source;
+  final int workoutsFound;
+  final int workoutsCreated;
+  final int setsCreated;
+  final int exercisesMatched;
+
+  /// Names that had no catalog or custom counterpart and were created as the
+  /// user's custom exercises — the candidates for promoting into the shared
+  /// library.
+  final List<String> exercisesCreated;
+  final int rowsSkipped;
+
+  const WorkoutImportReport({
+    required this.source,
+    required this.workoutsFound,
+    required this.workoutsCreated,
+    required this.setsCreated,
+    required this.exercisesMatched,
+    required this.exercisesCreated,
+    required this.rowsSkipped,
+  });
+
+  int get workoutsSkipped => workoutsFound - workoutsCreated;
+
+  factory WorkoutImportReport.fromRow(Map<String, dynamic> row, {required String source, required int rowsSkipped}) {
+    return WorkoutImportReport(
+      source: source,
+      workoutsFound: row['workouts_found'],
+      workoutsCreated: row['workouts_created'],
+      setsCreated: row['sets_created'],
+      exercisesMatched: row['exercises_matched'],
+      exercisesCreated: (row['exercises_created'] as List).cast<String>(),
+      rowsSkipped: rowsSkipped,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'source': source,
+      'workoutsFound': workoutsFound,
+      'workoutsCreated': workoutsCreated,
+      'workoutsSkipped': workoutsSkipped,
+      'setsCreated': setsCreated,
+      'exercisesMatched': exercisesMatched,
+      'exercisesCreated': exercisesCreated,
+      'rowsSkipped': rowsSkipped,
+    };
+  }
+}
+
+/// Minimal RFC-4180 CSV: quoted fields, doubled-quote escapes, newlines
+/// inside quotes, any of CRLF/LF/CR as row breaks. Fully-empty lines are
+/// dropped.
+List<List<String>> parseCsv(String text, {String delimiter = ','}) {
+  final rows = <List<String>>[];
+  var row = <String>[];
+  final field = StringBuffer();
+  var inQuotes = false;
+
+  void endField() {
+    row.add(field.toString());
+    field.clear();
+  }
+
+  void endRow() {
+    endField();
+    if (row.length > 1 || row.first.isNotEmpty) rows.add(row);
+    row = [];
+  }
+
+  for (var i = 0; i < text.length; i++) {
+    final c = text[i];
+    if (inQuotes) {
+      if (c == '"') {
+        if (i + 1 < text.length && text[i + 1] == '"') {
+          field.write('"');
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field.write(c);
+      }
+    } else if (c == '"') {
+      inQuotes = true;
+    } else if (c == delimiter) {
+      endField();
+    } else if (c == '\r') {
+      if (i + 1 < text.length && text[i + 1] == '\n') i++;
+      endRow();
+    } else if (c == '\n') {
+      endRow();
+    } else {
+      field.write(c);
+    }
+  }
+  if (field.isNotEmpty || row.isNotEmpty) endRow();
+  return rows;
+}
+
+class _WorkoutBuilder {
+  final String importId;
+  final String? name;
+  final DateTime start;
+  final DateTime? end;
+  final _exercises = <String, List<ImportedSet>>{};
+
+  _WorkoutBuilder({required this.importId, required this.name, required this.start, required this.end});
+
+  List<ImportedSet> exercise(String name) => _exercises.putIfAbsent(name, () => []);
+
+  ImportedWorkout build() {
+    return ImportedWorkout(
+      importId: importId,
+      name: name,
+      start: start,
+      end: end,
+      exercises: [
+        for (final MapEntry(key: name, value: sets) in _exercises.entries) ImportedExercise(name: name, sets: sets),
+      ],
+    );
+  }
+}
+
+String _detectDelimiter(String csv) {
+  final firstLine = csv.split('\n').first;
+  return !firstLine.contains(',') && firstLine.contains(';') ? ';' : ',';
+}
+
+/// `"Workout Name"` → `workoutname`, `"Weight (kg)"` → `weightkg`
+String _normalized(String header) => header.toLowerCase().replaceAll(RegExp('[^a-z]'), '');
+
+/// A unit baked into a normalized header name: `weightkg` → `kg`.
+String? _unitIn(String normalizedHeader) {
+  for (final unit in const ['kg', 'lbs', 'lb', 'meters', 'km', 'miles']) {
+    if (normalizedHeader.endsWith(unit)) return unit;
+  }
+  return null;
+}
+
+/// Strong timestamps are naive local time (`2023-01-15 17:35:12`); pins one
+/// to an instant using the exporting device's [utcOffset].
+DateTime _instant(String raw, Duration utcOffset) {
+  final normalized = raw.trim().replaceFirst(' ', 'T');
+  if (RegExp(r'(Z|[+-]\d{2}:?\d{2})$').hasMatch(normalized)) return DateTime.parse(normalized).toUtc();
+  return DateTime.parse('${normalized}Z').subtract(utcOffset);
+}
+
+/// `1h 10m`, `47m`, `1h 5m 30s`, `1:10:00`, `70:00` — Strong has used all of
+/// these for workout duration.
+Duration? _parseDuration(String? raw) {
+  // commas are thousands separators in runaway durations ("3,527h 3min")
+  final t = raw?.trim().toLowerCase().replaceAll(',', '');
+  if (t == null || t.isEmpty) return null;
+  if (t.contains(':')) {
+    final parts = t.split(':').map(int.tryParse).toList();
+    return switch (parts) {
+      [final int m, final int s] => Duration(minutes: m, seconds: s),
+      [final int h, final int m, final int s] => Duration(hours: h, minutes: m, seconds: s),
+      _ => null,
+    };
+  }
+  final tokens = RegExp(r'(\d+)\s*(h|m|s)').allMatches(
+    t.replaceAll('hours', 'h').replaceAll('hour', 'h').replaceAll('min', 'm').replaceAll('sec', 's'),
+  );
+  if (tokens.isEmpty) return null;
+  var total = Duration.zero;
+  for (final token in tokens) {
+    final value = int.parse(token.group(1)!);
+    total += switch (token.group(2)!) {
+      'h' => Duration(hours: value),
+      'm' => Duration(minutes: value),
+      _ => Duration(seconds: value),
+    };
+  }
+  return total;
+}
+
+/// Zero means "unset" in Strong exports, so it maps to null rather than a
+/// stored zero. Tolerates a decimal comma from `;`-delimited locales.
+double? _number(String? raw) {
+  if (raw == null) return null;
+  final parsed = double.tryParse(raw) ?? double.tryParse(raw.replaceAll(',', '.'));
+  if (parsed == null) throw FormatException('not a number: $raw');
+  return parsed == 0 ? null : parsed;
+}
+
+int? _count(String? raw) => _number(raw)?.round();
+
+double? _toKilograms(double? value, String? unit, MeasurementUnit fallback) {
+  if (value == null) return null;
+  return switch (unit?.trim().toLowerCase()) {
+    'kg' || 'kgs' || 'kilograms' => value,
+    'lb' || 'lbs' || 'pounds' => value.asKilograms,
+    _ => fallback == MeasurementUnit.imperial ? value.asKilograms : value,
+  };
+}
+
+double? _toKilometers(double? value, String? unit, MeasurementUnit fallback) {
+  if (value == null) return null;
+  return switch (unit?.trim().toLowerCase()) {
+    'km' || 'kilometers' => value,
+    'meters' || 'm' => value / 1000,
+    'miles' || 'mi' => value.asKilometers,
+    _ => fallback == MeasurementUnit.imperial ? value.asKilometers : value,
+  };
+}
+
+/// Best-effort category for an exercise we have to create: the equipment
+/// modifier in the name when it maps cleanly, otherwise inferred from what
+/// its sets actually record.
+String _category(String name, ({bool weight, bool distance, bool seconds}) shape) {
+  final n = name.toLowerCase();
+  if (n.contains('(barbell)')) return 'Barbell';
+  if (n.contains('(dumbbell)') || n.contains('(kettlebell)')) return 'Dumbbell';
+  if (n.contains('(machine)') || n.contains('(cable)') || n.contains('(smith machine)')) return 'Machine';
+  if (shape.distance) return 'Cardio';
+  if (shape.seconds && !shape.weight) return 'Duration';
+  if (shape.weight) return 'Weighted Body Weight';
+  return 'Reps Only';
+}

--- a/api/lib/models/workouts.dart
+++ b/api/lib/models/workouts.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:heart_models/heart_models.dart';
 
+import 'imports.dart';
+
 abstract interface class ApiWorkoutService {
   Future<Page<Workout>> getWorkouts({
     required String userId,
@@ -53,6 +55,15 @@ abstract interface class ApiWorkoutService {
   Future<void> deleteWorkout({
     required String userId,
     required String workoutId,
+  });
+
+  /// Bulk-writes a parsed CSV export in one shot: resolves or creates the
+  /// exercises it references, then inserts the workouts that aren't already
+  /// imported (matched on their deterministic import id, so re-runs are
+  /// no-ops).
+  Future<WorkoutImportReport> importWorkouts({
+    required String userId,
+    required WorkoutImport batch,
   });
 }
 

--- a/api/lib/routes/index.dart
+++ b/api/lib/routes/index.dart
@@ -60,6 +60,7 @@ final routes = <(String, Method), ModelHandler>{
   ('/templates/:templateId', .delete): templates.deleteMyTemplate,
   ('/templates/shares/:shareId', .delete): templates.deleteMyTemplateShare,
   ('/workouts', .post): workouts.createWorkout,
+  ('/workouts/imports', .post): workouts.importWorkouts,
   ('/workouts/images', .get): images.getGallery,
   ('/workouts/:workoutId', .get): workouts.getWorkout,
   ('/workouts/:workoutId', .put): workouts.updateWorkout,

--- a/api/lib/routes/workouts.dart
+++ b/api/lib/routes/workouts.dart
@@ -5,6 +5,7 @@ import 'package:heart/inputs/inputs.dart';
 import 'package:heart/middleware/database.dart';
 import 'package:heart/middleware/s3.dart';
 import 'package:heart/models/errors.dart';
+import 'package:heart/models/imports.dart';
 import 'package:heart/models/pagination.dart';
 import 'package:heart/models/workouts.dart';
 import 'package:heart_models/heart_models.dart';
@@ -53,6 +54,14 @@ Future<Workout> createWorkout(final Request request) async {
     body: workout,
     imageUrl: request.config.cdnAssetUrl,
   );
+}
+
+/// Bulk import of another app's CSV export; responds with a report of what
+/// was created, skipped (already imported), and which exercises had to be
+/// created as the user's customs.
+Future<WorkoutImportReport> importWorkouts(final Request request) async {
+  final input = await ImportWorkoutsIn.fromRequest(request);
+  return request.workoutsService.importWorkouts(userId: request.userId, batch: input.batch);
 }
 
 Future<Workout> updateWorkout(final Request request) async {

--- a/api/test/db/imports_db_test.dart
+++ b/api/test/db/imports_db_test.dart
@@ -1,0 +1,143 @@
+@Tags(['db'])
+library;
+
+import 'package:heart/models/imports.dart';
+import 'package:test/test.dart';
+
+import 'db_test_utility.dart';
+
+/// Integration coverage of the bulk-import query against live Postgres:
+/// exercise resolve-or-create, workout/set insertion, and the
+/// (user_id, import_id) idempotency that makes re-running an export a no-op.
+///
+/// Tagged `db` — skipped by the default `dart test`. Run with:
+///   dart test --run-skipped -t db
+void main() {
+  final h = _Harness();
+
+  late String ownerId;
+  late String benchName; // pre-seeded global exercise — must resolve, not copy
+  late String customName; // only in the CSV — must be created as the user's own
+  late String cardioName; // only in the CSV — category inferred from set shape
+
+  String csv() =>
+      'Date,Workout Name,Duration,Exercise Name,Set Order,Weight,Reps,Distance,Seconds\n'
+      '2023-01-15 17:35:12,Push Day,1h 10m,$benchName,1,80,5,0,0\n'
+      '2023-01-15 17:35:12,Push Day,1h 10m,$benchName,2,85,3,0,0\n'
+      '2023-01-15 17:35:12,Push Day,1h 10m,$customName,1,25,12,0,0\n'
+      '2023-01-17 08:00:00,Morning Run,45m,$cardioName,1,0,0,5.2,1800\n';
+
+  setUpAll(() async {
+    await h.setupDatabase();
+    ownerId = await h.seedProfile();
+    benchName = h.uniqueName('Bench');
+    customName = h.uniqueName('Kit Special Press');
+    cardioName = h.uniqueName('Ruck');
+    await h.seedGlobalExercise(name: benchName);
+  });
+
+  tearDownAll(() async {
+    // workout_exercises.exercise_id is ON DELETE RESTRICT; drop the imported
+    // workouts before the profile cascade tries to take the user's custom
+    // exercises with it.
+    await h.exec('DELETE FROM workouts WHERE user_id = @id', {'id': ownerId});
+    await h.teardownDatabase();
+  });
+
+  test('imports a parsed export end to end', () async {
+    final batch = WorkoutImport.fromStrongCsv(csv());
+    final report = await h.db.importWorkouts(userId: ownerId, batch: batch);
+
+    expect(report.workoutsFound, 2);
+    expect(report.workoutsCreated, 2);
+    expect(report.workoutsSkipped, 0);
+    expect(report.setsCreated, 4);
+    expect(report.exercisesMatched, 1);
+    expect(report.exercisesCreated, containsAll([customName, cardioName]));
+    expect(report.rowsSkipped, 0);
+  });
+
+  test('wrote the workout rows with their import identity and window', () async {
+    final rows = await h.exec(
+      'SELECT name, started_at, completed_at, import_id FROM workouts WHERE user_id = @id ORDER BY started_at',
+      {'id': ownerId},
+    );
+    expect(rows, hasLength(2));
+
+    final push = rows.first.toColumnMap();
+    expect(push['name'], 'Push Day');
+    expect(push['import_id'], 'strong:2023-01-15 17:35:12#Push Day');
+    expect((push['started_at'] as DateTime).toUtc(), DateTime.utc(2023, 1, 15, 17, 35, 12));
+    expect((push['completed_at'] as DateTime).toUtc(), DateTime.utc(2023, 1, 15, 18, 45, 12));
+  });
+
+  test('resolved the known name to the global exercise instead of copying it', () async {
+    final rows = await h.exec(
+      'SELECT DISTINCT e.user_id FROM exercises e '
+      'JOIN workout_exercises we ON we.exercise_id = e.id '
+      'JOIN workouts w ON w.id = we.workout_id '
+      'WHERE w.user_id = @id AND e.name = @n',
+      {'id': ownerId, 'n': benchName},
+    );
+    expect(rows, hasLength(1));
+    expect(rows.first.toColumnMap()['user_id'], isNull);
+  });
+
+  test('created unknown names as the user\'s customs with inferred categories', () async {
+    final rows = await h.exec(
+      'SELECT name, category, target, user_id FROM exercises WHERE user_id = @id ORDER BY name',
+      {'id': ownerId},
+    );
+    final byName = {for (final r in rows) r.toColumnMap()['name']: r.toColumnMap()};
+    expect(byName.keys, containsAll([customName, cardioName]));
+    expect(byName[customName]!['category'], 'Weighted Body Weight');
+    expect(byName[cardioName]!['category'], 'Cardio');
+    expect(byName[customName]!['target'], 'Other');
+  });
+
+  test('wrote sets with metric measurements in row order', () async {
+    final rows = await h.exec(
+      'SELECT es.weight, es.reps, es.duration, es.distance, es.completed, es.set_order FROM exercise_sets es '
+      'JOIN workout_exercises we ON we.id = es.workout_exercise_id '
+      'JOIN exercises e ON e.id = we.exercise_id '
+      'JOIN workouts w ON w.id = we.workout_id '
+      'WHERE w.user_id = @id AND e.name = @n ORDER BY es.set_order',
+      {'id': ownerId, 'n': benchName},
+    );
+    expect(rows, hasLength(2));
+    final first = rows.first.toColumnMap();
+    expect(first['weight'], 80);
+    expect(first['reps'], 5);
+    expect(first['completed'], isTrue);
+    expect(first['set_order'], 0);
+    expect(rows.last.toColumnMap()['weight'], 85);
+  });
+
+  test('re-running the same export is a no-op, reported as skipped', () async {
+    final report = await h.db.importWorkouts(userId: ownerId, batch: WorkoutImport.fromStrongCsv(csv()));
+
+    expect(report.workoutsFound, 2);
+    expect(report.workoutsCreated, 0);
+    expect(report.workoutsSkipped, 2);
+    expect(report.setsCreated, 0);
+    // the customs created by the first run now resolve as the user's own
+    expect(report.exercisesMatched, 3);
+    expect(report.exercisesCreated, isEmpty);
+
+    final count = await h.exec('SELECT count(*) AS n FROM workouts WHERE user_id = @id', {'id': ownerId});
+    expect(count.first.toColumnMap()['n'], 2);
+  });
+
+  test('a grown export imports only the workouts not already there', () async {
+    final grown =
+        '${csv()}'
+        '2023-01-19 18:00:00,Legs,50m,$benchName,1,120,5,0,0\n';
+    final report = await h.db.importWorkouts(userId: ownerId, batch: WorkoutImport.fromStrongCsv(grown));
+
+    expect(report.workoutsFound, 3);
+    expect(report.workoutsCreated, 1);
+    expect(report.setsCreated, 1);
+  });
+}
+
+class _Harness extends DatabaseTestBase {}

--- a/api/test/helpers/request.dart
+++ b/api/test/helpers/request.dart
@@ -23,6 +23,25 @@ Request jsonRequest({
   );
 }
 
+/// Builds a request with a raw text body (e.g. a CSV upload), for handlers
+/// that read via `req.text()`.
+Request textRequest({
+  Method method = Method.post,
+  String path = '/',
+  String body = '',
+  MimeType mimeType = MimeType.csv,
+  Map<String, String> query = const {},
+  Map<String, String> extraHeaders = const {},
+}) {
+  return RequestInternal.create(
+    method,
+    _uri(path, query),
+    Object(),
+    body: Body.fromString(body, mimeType: mimeType),
+    headers: _headers(extraHeaders),
+  );
+}
+
 /// Builds a request with no body. Suitable for handlers that don't call
 /// `req.json()` (e.g. event handlers given userId directly, GET routes that
 /// read only query params).

--- a/api/test/models/imports_test.dart
+++ b/api/test/models/imports_test.dart
@@ -1,0 +1,224 @@
+import 'package:heart/models/imports.dart';
+import 'package:heart_models/heart_models.dart';
+import 'package:test/test.dart';
+
+/// A realistic Strong export: one row per set, quoted fields with embedded
+/// commas/quotes, zeros meaning "unset", and an RPE column we ignore.
+const _strongCsv =
+    'Date,Workout Name,Duration,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE\n'
+    '2023-01-15 17:35:12,Push Day,1h 10m,Bench Press (Barbell),1,80,5,0,0,,,8\n'
+    '2023-01-15 17:35:12,Push Day,1h 10m,Bench Press (Barbell),2,85,3,0,0,,,9\n'
+    '2023-01-15 17:35:12,Push Day,1h 10m,"Fly, Seated (Cable)",1,25,12,0,0,"felt ""good""",,\n'
+    '2023-01-17 08:00:00,Morning Run,45m,Running,1,0,0,5.2,1800,,,\n'
+    '2023-01-18 18:00:00,Core,30m,Plank,1,0,0,0,60,,,\n'
+    '2023-01-18 18:00:00,Core,30m,Sit Up,1,0,15,0,0,,,\n';
+
+void main() {
+  group('WorkoutImport.fromStrongCsv', () {
+    final batch = WorkoutImport.fromStrongCsv(_strongCsv);
+
+    test('groups one-row-per-set into workouts by date and name', () {
+      expect(batch.workouts, hasLength(3));
+      expect(batch.workouts.map((w) => w.name), ['Push Day', 'Morning Run', 'Core']);
+      expect(batch.rowsSkipped, 0);
+    });
+
+    test('groups sets under their exercise, preserving first-appearance order', () {
+      final push = batch.workouts.first;
+      expect(push.exercises.map((e) => e.name), ['Bench Press (Barbell)', 'Fly, Seated (Cable)']);
+      expect(push.exercises.first.sets, hasLength(2));
+    });
+
+    test('parses set measurements, mapping zero to null', () {
+      final bench = batch.workouts.first.exercises.first.sets;
+      expect(bench.first.weight, 80);
+      expect(bench.first.reps, 5);
+      expect(bench.first.distance, isNull);
+      expect(bench.first.duration, isNull);
+
+      final run = batch.workouts[1].exercises.single.sets.single;
+      expect(run.weight, isNull);
+      expect(run.distance, 5.2);
+      expect(run.duration, 1800);
+    });
+
+    test('derives the workout window from Date plus Duration', () {
+      final push = batch.workouts.first;
+      expect(push.start, DateTime.utc(2023, 1, 15, 17, 35, 12));
+      expect(push.end, DateTime.utc(2023, 1, 15, 18, 45, 12));
+    });
+
+    test('pins naive local timestamps using the device utc offset', () {
+      final shifted = WorkoutImport.fromStrongCsv(_strongCsv, utcOffset: const Duration(hours: 2));
+      expect(shifted.workouts.first.start, DateTime.utc(2023, 1, 15, 15, 35, 12));
+    });
+
+    test('derives a deterministic import id from the source row', () {
+      expect(batch.workouts.first.importId, 'strong:2023-01-15 17:35:12#Push Day');
+      final again = WorkoutImport.fromStrongCsv(_strongCsv);
+      expect(again.workouts.first.importId, batch.workouts.first.importId);
+    });
+
+    test('lists distinct exercises with inferred categories', () {
+      final byName = {for (final e in batch.exercises) e['name']: e};
+      expect(byName.keys, hasLength(5));
+      expect(byName['Bench Press (Barbell)']!['category'], 'Barbell');
+      expect(byName['Fly, Seated (Cable)']!['category'], 'Machine');
+      expect(byName['Running']!['category'], 'Cardio');
+      expect(byName['Plank']!['category'], 'Duration');
+      expect(byName['Sit Up']!['category'], 'Reps Only');
+      expect(byName.values.every((e) => e['target'] == 'Other'), isTrue);
+    });
+
+    test('skips and counts unparseable rows instead of failing the batch', () {
+      final withBadRow =
+          '$_strongCsv'
+          '2023-01-19 10:00:00,Legs,20m,Squat (Barbell),1,not-a-number,5,0,0,,,\n';
+      final parsed = WorkoutImport.fromStrongCsv(withBadRow);
+      expect(parsed.rowsSkipped, 1);
+      expect(parsed.workouts, hasLength(3));
+    });
+
+    test('repairs rows shifted by an unquoted thousands separator in Duration', () {
+      // Strong exports a runaway workout as "3,527h 3min" without quoting,
+      // splitting the field and pushing every later column one to the right
+      const csv =
+          'Date,Workout Name,Duration,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE\n'
+          '2024-07-22 17:45:06,"Legs",3,527h 3min,"Leg Press",1,450.0,12.0,0,0.0,"","",\n';
+      final batch = WorkoutImport.fromStrongCsv(csv);
+      final workout = batch.workouts.single;
+      expect(workout.exercises.single.name, 'Leg Press');
+      expect(workout.exercises.single.sets.single.weight, 450);
+      expect(workout.exercises.single.sets.single.reps, 12);
+      expect(batch.rowsSkipped, 0);
+    });
+
+    test('drops the end timestamp when the duration is a left-running artifact', () {
+      const csv =
+          'Date,Workout Name,Duration,Exercise Name,Weight,Reps\n'
+          '2024-07-22 17:45:06,Legs,"3,527h 3min",Squat (Barbell),100,5\n'
+          '2024-07-23 17:45:06,Push,12h 56min,Bench Press (Barbell),80,5\n';
+      final batch = WorkoutImport.fromStrongCsv(csv);
+      expect(batch.workouts.first.end, isNull);
+      // under 24h is kept — a long day is not corrupt data
+      expect(batch.workouts.last.end, DateTime.utc(2024, 7, 24, 6, 41, 6));
+    });
+
+    test('rejects a file without the Strong columns', () {
+      expect(() => WorkoutImport.fromStrongCsv('a,b,c\n1,2,3\n'), throwsFormatException);
+      expect(() => WorkoutImport.fromStrongCsv(''), throwsFormatException);
+    });
+  });
+
+  group('unit handling', () {
+    test('metric fallback stores weights as-is', () {
+      final batch = WorkoutImport.fromStrongCsv(_strongCsv);
+      expect(batch.workouts.first.exercises.first.sets.first.weight, 80);
+    });
+
+    test('imperial fallback converts lbs to kg and miles to km', () {
+      final batch = WorkoutImport.fromStrongCsv(_strongCsv, unit: MeasurementUnit.imperial);
+      expect(batch.workouts.first.exercises.first.sets.first.weight, closeTo(36.29, 0.01));
+      expect(batch.workouts[1].exercises.single.sets.single.distance, closeTo(8.37, 0.01));
+    });
+
+    test('a Weight Unit column beats the fallback, per row', () {
+      const csv =
+          'Date,Workout Name,Duration,Exercise Name,Weight,Weight Unit,Reps\n'
+          '2023-01-15 17:35:12,Mixed,1h,Bench Press (Barbell),100,lbs,5\n'
+          '2023-01-15 17:35:12,Mixed,1h,Squat (Barbell),100,kg,5\n';
+      final batch = WorkoutImport.fromStrongCsv(csv);
+      final sets = [for (final e in batch.workouts.single.exercises) e.sets.single];
+      expect(sets.first.weight, closeTo(45.36, 0.01));
+      expect(sets.last.weight, 100);
+    });
+
+    test('a unit baked into the header ("Weight (kg)") beats the fallback', () {
+      const csv =
+          'Date,Workout Name,Exercise Name,Weight (kg),Reps\n'
+          '2023-01-15 17:35:12,Push,Bench Press (Barbell),100,5\n';
+      final batch = WorkoutImport.fromStrongCsv(csv, unit: MeasurementUnit.imperial);
+      expect(batch.workouts.single.exercises.single.sets.single.weight, 100);
+    });
+
+    test('"Distance (meters)" converts to kilometers', () {
+      const csv =
+          'Date,Workout Name,Exercise Name,Distance (meters),Seconds\n'
+          '2023-01-15 17:35:12,Run,Running,5200,1800\n';
+      final batch = WorkoutImport.fromStrongCsv(csv);
+      expect(batch.workouts.single.exercises.single.sets.single.distance, closeTo(5.2, 0.001));
+    });
+
+    test('semicolon-delimited exports with decimal commas parse', () {
+      const csv =
+          'Date;Workout Name;Duration;Exercise Name;Weight;Reps\n'
+          '2023-01-15 17:35:12;Push;1h;Bench Press (Barbell);82,5;5\n';
+      final batch = WorkoutImport.fromStrongCsv(csv);
+      expect(batch.workouts.single.exercises.single.sets.single.weight, 82.5);
+    });
+  });
+
+  group('payload and report', () {
+    test('toParams encodes workouts and exercises as JSON strings', () {
+      final params = WorkoutImport.fromStrongCsv(_strongCsv).toParams(userId: 'u1');
+      expect(params['userId'], 'u1');
+      expect(params['workouts'], isA<String>());
+      expect(params['exercises'], isA<String>());
+      expect(params['workouts'], contains('"importId":"strong:2023-01-15 17:35:12#Push Day"'));
+    });
+
+    test('set payload omits null measurements', () {
+      const set = ImportedSet(weight: 80, reps: 5);
+      expect(set.toPayload(), {'weight': 80, 'reps': 5});
+    });
+
+    test('report round-trips from a result row and derives workoutsSkipped', () {
+      final report = WorkoutImportReport.fromRow(
+        {
+          'workouts_found': 10,
+          'workouts_created': 7,
+          'sets_created': 120,
+          'exercises_matched': 15,
+          'exercises_created': ['Custom Curl'],
+        },
+        source: 'strong',
+        rowsSkipped: 2,
+      );
+      expect(report.toMap(), {
+        'source': 'strong',
+        'workoutsFound': 10,
+        'workoutsCreated': 7,
+        'workoutsSkipped': 3,
+        'setsCreated': 120,
+        'exercisesMatched': 15,
+        'exercisesCreated': ['Custom Curl'],
+        'rowsSkipped': 2,
+      });
+    });
+  });
+
+  group('parseCsv', () {
+    test('keeps quoted delimiters, escaped quotes, and newlines in one field', () {
+      final rows = parseCsv('a,"b,\nc","d""e"\n1,2,3\n');
+      expect(rows, [
+        ['a', 'b,\nc', 'd"e'],
+        ['1', '2', '3'],
+      ]);
+    });
+
+    test('handles CRLF rows and drops fully empty lines', () {
+      final rows = parseCsv('a,b\r\n\r\n1,2\r\n');
+      expect(rows, [
+        ['a', 'b'],
+        ['1', '2'],
+      ]);
+    });
+
+    test('keeps the last row without a trailing newline', () {
+      expect(parseCsv('a,b\n1,2'), [
+        ['a', 'b'],
+        ['1', '2'],
+      ]);
+    });
+  });
+}

--- a/api/test/routes/workouts_test.dart
+++ b/api/test/routes/workouts_test.dart
@@ -2,6 +2,7 @@ import 'package:heart/globals/config.dart';
 import 'package:heart/globals/globals.dart';
 import 'package:heart/middleware/database.dart';
 import 'package:heart/models/errors.dart';
+import 'package:heart/models/imports.dart';
 import 'package:heart/routes/workouts.dart';
 import 'package:heart_models/heart_models.dart';
 import 'package:mockito/mockito.dart';
@@ -224,6 +225,64 @@ void main() {
       await expectLater(
         patchWorkoutById(patchReq({'name': 'x'}), 'w-1'),
         throwsA(isA<NotFound>()),
+      );
+    });
+  });
+
+  group('importWorkouts', () {
+    const csv =
+        'Date,Workout Name,Duration,Exercise Name,Set Order,Weight,Reps,Distance,Seconds\n'
+        '2023-01-15 17:35:12,Push Day,1h,Bench Press (Barbell),1,80,5,0,0\n';
+
+    const report = WorkoutImportReport(
+      source: 'strong',
+      workoutsFound: 1,
+      workoutsCreated: 1,
+      setsCreated: 1,
+      exercisesMatched: 1,
+      exercisesCreated: [],
+      rowsSkipped: 0,
+    );
+
+    Request importReq({String body = csv, Map<String, String> query = const {'source': 'strong'}}) =>
+        wire(textRequest(path: '/workouts/imports', body: body, query: query));
+
+    test('parses the CSV and hands the batch to the service under the caller id', () async {
+      when(
+        workouts.importWorkouts(userId: anyNamed('userId'), batch: anyNamed('batch')),
+      ).thenAnswer((_) async => report);
+
+      final result = await importWorkouts(importReq());
+
+      expect(result.toMap()['workoutsCreated'], 1);
+      final batch =
+          verify(
+                workouts.importWorkouts(userId: _meId, batch: captureAnyNamed('batch')),
+              ).captured.single
+              as WorkoutImport;
+      expect(batch.source, 'strong');
+      expect(batch.workouts.single.name, 'Push Day');
+    });
+
+    test('rejects a missing source', () async {
+      await expectLater(importWorkouts(importReq(query: {})), throwsA(isA<BadRequest>()));
+    });
+
+    test('rejects an unsupported source', () async {
+      await expectLater(
+        importWorkouts(importReq(query: {'source': 'hevy'})),
+        throwsA(isA<BadRequest>()),
+      );
+    });
+
+    test('rejects a body that is not a Strong export', () async {
+      await expectLater(importWorkouts(importReq(body: 'a,b\n1,2\n')), throwsA(isA<BadRequest>()));
+    });
+
+    test('rejects a malformed tzOffset', () async {
+      await expectLater(
+        importWorkouts(importReq(query: {'source': 'strong', 'tzOffset': 'PST'})),
+        throwsA(isA<BadRequest>()),
       );
     });
   });

--- a/database/migrations/2026-08-09.workout-imports.sql
+++ b/database/migrations/2026-08-09.workout-imports.sql
@@ -1,0 +1,15 @@
+-- Bulk CSV import (Strong today, Hevy later): each imported workout carries a
+-- deterministic identity derived from its source row (e.g.
+-- 'strong:<date>#<workout name>'), so re-running the same export is a no-op
+-- instead of a duplicated history. NULL for workouts created through the
+-- app's own write path.
+
+ALTER TABLE workouts
+    ADD COLUMN IF NOT EXISTS import_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS workouts_user_import_id_idx
+    ON workouts (user_id, import_id)
+    WHERE import_id IS NOT NULL;
+
+COMMENT ON COLUMN workouts.import_id IS
+    'Deterministic source identity for bulk-imported workouts (''<source>:<date>#<workout name>''); unique per user, NULL for app-created workouts';

--- a/database/tests/public/tables/workouts.sql
+++ b/database/tests/public/tables/workouts.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(20);
+SELECT plan(24);
 
 SELECT has_table('public'::name, 'workouts'::name);
 
@@ -14,7 +14,8 @@ SELECT columns_are(
                    'started_at',
                    'completed_at',
                    'calories',
-                   'created_at'
+                   'created_at',
+                   'import_id'
                    ]
        );
 
@@ -25,6 +26,7 @@ SELECT col_type_is('public'::name, 'workouts'::name, 'started_at'::name, 'timest
 SELECT col_type_is('public'::name, 'workouts'::name, 'completed_at'::name, 'timestamp with time zone'::name);
 SELECT col_type_is('public'::name, 'workouts'::name, 'calories'::name, 'real'::name);
 SELECT col_type_is('public'::name, 'workouts'::name, 'created_at'::name, 'timestamp with time zone'::name);
+SELECT col_type_is('public'::name, 'workouts'::name, 'import_id'::name, 'text'::name);
 
 SELECT has_pk('public'::name, 'workouts'::name, 'workouts has a primary key');
 SELECT col_is_pk('public'::name, 'workouts'::name, 'id'::name, 'id is the primary key');
@@ -39,6 +41,8 @@ SELECT col_default_is('public', 'workouts', 'created_at', 'now()', 'created_at d
 SELECT fk_ok('public', 'workouts', 'user_id', 'public', 'profiles', 'id');
 
 SELECT has_index('public'::name, 'workouts'::name, 'workouts_user_id_idx'::name);
+SELECT has_index('public'::name, 'workouts'::name, 'workouts_user_import_id_idx'::name);
+SELECT index_is_unique('public'::name, 'workouts'::name, 'workouts_user_import_id_idx'::name);
 
 -- fixture for the CHECK-constraint assertions below
 DO
@@ -58,6 +62,21 @@ SELECT throws_ok(
                '23514',
                NULL,
                'negative calories are rejected'
+       );
+
+-- first import row for the duplicate-identity assertion below
+DO
+$$
+BEGIN
+    INSERT INTO workouts (user_id, import_id) VALUES ('w-check-user', 'strong:2023-01-15 17:35:12#Push');
+END
+$$;
+
+SELECT throws_ok(
+               $$ INSERT INTO workouts (user_id, import_id) VALUES ('w-check-user', 'strong:2023-01-15 17:35:12#Push') $$,
+               '23505',
+               NULL,
+               'the same import identity cannot land twice for one user'
        );
 
 SELECT *


### PR DESCRIPTION
### Description

This pull request introduces a new feature to support bulk workout imports from Strong CSV exports. A new endpoint, `POST /workouts/imports?source=strong`, is implemented to handle raw CSV input. Key functionalities include:

- Parsing of one-row-per-set Strong CSV exports, accommodating format variations and normalizing units to metric.
- Resolution of exercise names against the catalog, with new customs created as needed.
- Atomic database insertion with deterministic import IDs to ensure re-runs are idempotent.
- A detailed response that reports created/skipped workouts, processed sets, and both matched and newly created exercises.

This implementation was validated against real-world data, addressing quirks such as unquoted thousands-separator durations and left-running durations exceeding 24 hours.
