### PR TITLE
Add support for per-exercise notes in workouts

### DIFF
--- a/api/lib/db/queries.dart
+++ b/api/lib/db/queries.dart
@@ -362,7 +362,8 @@ _order_to_name AS (
   SELECT
     (ex->>'order')::int AS exercise_order,
     ex->>'exercise_name' AS exercise_name,
-    (ex->>'met')::real AS met
+    (ex->>'met')::real AS met,
+    ex->>'note' AS note
   FROM jsonb_array_elements(@exercises::jsonb) ex
 ),
 _exercise_lookup AS (
@@ -378,12 +379,12 @@ _workout AS (
   RETURNING id, name, started_at, completed_at, calories, created_at
 ),
 _inserted_exercises AS (
-  INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, met)
-  SELECT w.id, el.exercise_id, otn.exercise_order, otn.met
+  INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, met, note)
+  SELECT w.id, el.exercise_id, otn.exercise_order, otn.met, otn.note
   FROM _workout w
   CROSS JOIN _order_to_name otn
   JOIN _exercise_lookup el ON el.name = otn.exercise_name
-  RETURNING id, exercise_order, met
+  RETURNING id, exercise_order, met, note
 ),
 _sets_input AS (
   SELECT
@@ -440,6 +441,7 @@ _exercises_json AS (
       ),
       'exercise_order', ie.exercise_order,
       'met', ie.met,
+      'note', ie.note,
       'sets', COALESCE(sj.sets_json, '[]'::jsonb)
     ) ORDER BY ie.exercise_order
   ) AS exercises_json
@@ -550,7 +552,8 @@ _order_to_name AS (
   SELECT
     (ex->>'order')::int AS exercise_order,
     ex->>'exercise_name' AS exercise_name,
-    (ex->>'met')::real AS met
+    (ex->>'met')::real AS met,
+    ex->>'note' AS note
   FROM jsonb_array_elements(@exercises::jsonb) ex
 ),
 _exercise_lookup AS (
@@ -572,17 +575,18 @@ _deleted AS (
   RETURNING id
 ),
 _inserted_exercises AS (
-  INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, met)
+  INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, met, note)
   SELECT
     w.id,
     el.exercise_id,
     otn.exercise_order,
-    otn.met
+    otn.met,
+    otn.note
   FROM _workout w
   CROSS JOIN _order_to_name otn
   JOIN _exercise_lookup el ON el.name = otn.exercise_name
   WHERE NOT exists(SELECT 1 FROM _deleted WHERE false)
-  RETURNING id, exercise_order, met
+  RETURNING id, exercise_order, met, note
 ),
 _sets_input AS (
   SELECT
@@ -639,6 +643,7 @@ _exercises_json AS (
       ),
       'exercise_order', ie.exercise_order,
       'met', ie.met,
+      'note', ie.note,
       'sets', coalesce(sj.sets_json, '[]'::jsonb)
     ) ORDER BY ie.exercise_order
   ) AS exercises_json

--- a/api/lib/models/workouts.dart
+++ b/api/lib/models/workouts.dart
@@ -2,7 +2,11 @@ import 'dart:convert';
 
 import 'package:heart_models/heart_models.dart';
 
+<<<<<<< Updated upstream
 import 'imports.dart';
+=======
+import 'errors.dart';
+>>>>>>> Stashed changes
 
 abstract interface class ApiWorkoutService {
   Future<Page<Workout>> getWorkouts({
@@ -95,6 +99,7 @@ class WorkoutRequest {
               'exercise_name': name,
               'order': ex['order'],
               'met': ?ex['met'],
+              'note': ?_note(ex['note']),
               'sets': ex['sets'] ?? [],
             };
           },
@@ -102,6 +107,25 @@ class WorkoutRequest {
         .where((e) => e['exercise_name'] != null)
         .toList();
   }
+
+  /// Normalises a per-exercise note: trims, treats blank as absent (a cleared pin
+  /// is no pin), and caps the length so it stays a pin, not an essay — comments
+  /// are the place for prose. Over-long is a clean 400, not a raw DB CHECK error.
+  static String? _note(Object? value) {
+    if (value == null) return null;
+    if (value is! String) throw const BadRequest(reason: 'an exercise note must be a string');
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    if (trimmed.length > _maxNoteLength) {
+      throw const BadRequest(
+        code: 'workout_note_too_long',
+        reason: 'an exercise note is at most $_maxNoteLength characters',
+      );
+    }
+    return trimmed;
+  }
+
+  static const _maxNoteLength = 500;
 
   Map<String, dynamic> toParams() {
     return {

--- a/api/lib/models/workouts.dart
+++ b/api/lib/models/workouts.dart
@@ -2,11 +2,8 @@ import 'dart:convert';
 
 import 'package:heart_models/heart_models.dart';
 
-<<<<<<< Updated upstream
-import 'imports.dart';
-=======
 import 'errors.dart';
->>>>>>> Stashed changes
+import 'imports.dart';
 
 abstract interface class ApiWorkoutService {
   Future<Page<Workout>> getWorkouts({

--- a/api/test/db/workouts_db_test.dart
+++ b/api/test/db/workouts_db_test.dart
@@ -297,6 +297,42 @@ void main() {
       expect(read.first.first.completedAt?.toUtc(), DateTime.utc(2026, 8, 8, 10, 1, 30));
     });
 
+    test('a per-exercise note round-trips through create, read, and a full-replace update', () async {
+      final exName = h.uniqueName('Ex');
+      await h.seedGlobalExercise(name: exName);
+
+      WorkoutRequest withNote(String note) => WorkoutRequest(
+        userId: ownerId,
+        body: {
+          'name': 'Noted workout',
+          'start': '2026-08-08T10:00:00Z',
+          'end': '2026-08-08T11:00:00Z',
+          'exercises': [
+            {'exercise': exName, 'order': 0, 'note': note, 'sets': <Map>[]},
+          ],
+        },
+      );
+
+      final created = await h.db.createWorkout(
+        userId: ownerId,
+        body: withNote('do one hand at a time'),
+        imageUrl: imageUrl,
+      );
+      expect(created.first.note, 'do one hand at a time');
+
+      final read = await h.db.getWorkout(userId: ownerId, workoutId: created.id, imageUrl: imageUrl);
+      expect(read.first.note, 'do one hand at a time');
+
+      // updateWorkout deletes and re-inserts workout_exercises; the note must survive
+      final updated = await h.db.updateWorkout(
+        userId: ownerId,
+        workoutId: created.id,
+        body: withNote('pause at the bottom'),
+        imageUrl: imageUrl,
+      );
+      expect(updated.first.note, 'pause at the bottom');
+    });
+
     test('a calories-only patch sets calories and leaves the rest unchanged', () async {
       final id = await h.seedWorkout(userId: ownerId);
 

--- a/api/test/models/workouts_test.dart
+++ b/api/test/models/workouts_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_dynamic_calls
 import 'dart:convert';
 
+import 'package:heart/models/errors.dart';
 import 'package:heart/models/workouts.dart';
 import 'package:test/test.dart';
 
@@ -54,6 +55,35 @@ void main() {
       final exercises = jsonDecode(params['exercises'] as String) as List;
       expect(exercises[0]['met'], 5.5);
       expect(exercises[1], isNot(contains('met')));
+    });
+
+    test('forwards a per-exercise note, trimmed, dropping blank ones', () {
+      final req = const WorkoutRequest(
+        userId: 'u1',
+        body: {
+          'exercises': [
+            {'exercise': 'Bench Press (Barbell)', 'order': 0, 'note': '  do one hand at a time  ', 'sets': []},
+            {'exercise': 'Squat (Barbell)', 'order': 1, 'note': '   ', 'sets': []},
+          ],
+        },
+      );
+
+      final exercises = jsonDecode(req.toParams()['exercises'] as String) as List;
+      expect(exercises[0]['note'], 'do one hand at a time', reason: 'trimmed');
+      expect(exercises[1], isNot(contains('note')), reason: 'a blank note is dropped, not stored');
+    });
+
+    test('rejects an over-long note with a 400', () {
+      final req = WorkoutRequest(
+        userId: 'u1',
+        body: {
+          'exercises': [
+            {'exercise': 'Bench Press (Barbell)', 'order': 0, 'note': 'x' * 501, 'sets': []},
+          ],
+        },
+      );
+
+      expect(() => req.toParams(), throwsA(isA<BadRequest>()));
     });
 
     test('exercises encoded with name flattened from {exercise: name} or {exercise: {name}}', () {

--- a/database/migrations/2026-08-10.workout-exercise-note.sql
+++ b/database/migrations/2026-08-10.workout-exercise-note.sql
@@ -1,0 +1,53 @@
+-- A short, user-authored note pinned to a workout exercise — e.g. "do one hand
+-- at a time", "pause at the bottom". It is a description of how the exercise was
+-- (or should be) performed, distinct from a `comment`: a comment is social,
+-- threaded, and lives in its own table; a note is a single inline pin the owner
+-- writes and edits as part of the workout itself.
+--
+-- Plain user text, not a measurement, so unlike `met`/`calories` the device-only
+-- health rule does not touch it. Bounded to keep it a pin rather than an essay
+-- (that is what comments are for) and to stop a pathological payload bloating
+-- every workout read — the exercises blob is returned in full on every fetch.
+
+ALTER TABLE workout_exercises
+    ADD COLUMN IF NOT EXISTS note TEXT;
+
+ALTER TABLE workout_exercises
+    DROP CONSTRAINT IF EXISTS workout_exercises_note_length_check;
+ALTER TABLE workout_exercises
+    ADD CONSTRAINT workout_exercises_note_length_check
+        CHECK (note IS NULL OR char_length(note) BETWEEN 1 AND 500);
+
+COMMENT ON COLUMN workout_exercises.note IS
+    'Short user-authored pin describing how this exercise was performed (max 500 chars); NULL when the user left no note. Distinct from a comment.';
+
+-- Surface the new column in the read shape. The archive snapshot
+-- (archive.deleted_workouts.exercises) is built through this same function, so a
+-- deleted workout keeps its notes with no extra plumbing.
+DROP FUNCTION IF EXISTS _workout_exercises(_workout_id UUID);
+CREATE OR REPLACE FUNCTION _workout_exercises(_workout_id UUID)
+RETURNS JSONB
+LANGUAGE SQL AS
+$$
+SELECT COALESCE(
+  jsonb_agg(
+    jsonb_build_object(
+      'id', we.id,
+      'exercise', jsonb_build_object(
+          'id',       e.id,
+          'category', e.category,
+          'target',   e.target,
+          'name',     e.name
+      ),
+      'exercise_order', we.exercise_order,
+      'met',            we.met,
+      'note',           we.note,
+      'sets',           _exercise_sets(we.id)
+    ) ORDER BY we.exercise_order
+  ) FILTER (WHERE we.id IS NOT NULL),
+  '[]'::JSONB
+)
+FROM workout_exercises we
+LEFT JOIN exercises e ON e.id = we.exercise_id
+WHERE we.workout_id = _workout_id
+$$;

--- a/database/test_utils/helpers.sql
+++ b/database/test_utils/helpers.sql
@@ -191,7 +191,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION validate_format_workout_exercise(_we JSONB) RETURNS SETOF BOOL AS
 $$
 BEGIN
-    RETURN NEXT (SELECT count(*) FROM jsonb_object_keys(_we)) = 5;
+    RETURN NEXT (SELECT count(*) FROM jsonb_object_keys(_we)) = 6;
     RETURN NEXT jsonb_typeof(_we -> 'id') = 'string';
     RETURN NEXT jsonb_typeof(_we -> 'exercise') = 'object';
     RETURN NEXT (SELECT count(*) FROM jsonb_object_keys(_we -> 'exercise')) = 4;
@@ -201,6 +201,7 @@ BEGIN
     RETURN NEXT jsonb_typeof(_we -> 'exercise' -> 'target') = 'string';
     RETURN NEXT jsonb_typeof(_we -> 'exercise_order') = 'number';
     RETURN NEXT jsonb_typeof(_we -> 'met') = 'number' OR jsonb_typeof(_we -> 'met') = 'null';
+    RETURN NEXT jsonb_typeof(_we -> 'note') = 'string' OR jsonb_typeof(_we -> 'note') = 'null';
     RETURN NEXT jsonb_typeof(_we -> 'sets') = 'array';
 END
 $$ LANGUAGE plpgsql;

--- a/database/tests/public/functions/_workout_exercises.sql
+++ b/database/tests/public/functions/_workout_exercises.sql
@@ -82,7 +82,7 @@ BEGIN
     _w_id    := create_test_workout(_user_id => _user_id);
     _we_id   := create_test_workout_exercise(_w_id, _ex_id, 0);
     PERFORM create_test_exercise_set(_we_id, 0, 135, 5);
-    UPDATE workout_exercises SET met = 5.5 WHERE id = _we_id;
+    UPDATE workout_exercises SET met = 5.5, note = 'do one hand at a time' WHERE id = _we_id;
 
     _result := _workout_exercises(_w_id);
 
@@ -94,6 +94,7 @@ BEGIN
     RETURN NEXT is(_result -> 0 -> 'exercise' ->> 'category', 'Barbell', 'exercise.category preserved');
     RETURN NEXT is(_result -> 0 -> 'exercise' ->> 'target', 'Chest', 'exercise.target preserved');
     RETURN NEXT is((_result -> 0 ->> 'met')::real, 5.5::real, 'met preserved');
+    RETURN NEXT is(_result -> 0 ->> 'note', 'do one hand at a time', 'note preserved');
     RETURN NEXT is(jsonb_array_length(_result -> 0 -> 'sets'), 1, 'sets array populated');
 END
 $$ LANGUAGE plpgsql;

--- a/database/tests/public/tables/workout_exercises.sql
+++ b/database/tests/public/tables/workout_exercises.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(19);
+SELECT plan(23);
 
 SELECT has_table('public'::name, 'workout_exercises'::name);
 
@@ -12,7 +12,8 @@ SELECT columns_are(
                    'workout_id',
                    'exercise_id',
                    'exercise_order',
-                   'met'
+                   'met',
+                   'note'
                    ]
        );
 
@@ -21,6 +22,7 @@ SELECT col_type_is('public'::name, 'workout_exercises'::name, 'workout_id'::name
 SELECT col_type_is('public'::name, 'workout_exercises'::name, 'exercise_id'::name, 'uuid'::name);
 SELECT col_type_is('public'::name, 'workout_exercises'::name, 'exercise_order'::name, 'integer'::name);
 SELECT col_type_is('public'::name, 'workout_exercises'::name, 'met'::name, 'real'::name);
+SELECT col_type_is('public'::name, 'workout_exercises'::name, 'note'::name, 'text'::name);
 
 SELECT has_pk('public'::name, 'workout_exercises'::name, 'workout_exercises has a primary key');
 SELECT col_is_pk('public'::name, 'workout_exercises'::name, 'id'::name, 'id is the primary key');
@@ -70,6 +72,46 @@ SELECT throws_ok(
                '23514',
                NULL,
                'a negative met is rejected'
+       );
+
+SELECT lives_ok(
+               $$
+               INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, note)
+               VALUES (
+                   (SELECT id FROM workouts WHERE name = 'we check workout'),
+                   (SELECT id FROM exercises WHERE name = 'WE Check Bench'),
+                   2, 'do one hand at a time'
+               )
+               $$,
+               'a short note is allowed'
+       );
+
+SELECT throws_ok(
+               $$
+               INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, note)
+               VALUES (
+                   (SELECT id FROM workouts WHERE name = 'we check workout'),
+                   (SELECT id FROM exercises WHERE name = 'WE Check Bench'),
+                   3, repeat('x', 501)
+               )
+               $$,
+               '23514',
+               NULL,
+               'a note over 500 chars is rejected'
+       );
+
+SELECT throws_ok(
+               $$
+               INSERT INTO workout_exercises (workout_id, exercise_id, exercise_order, note)
+               VALUES (
+                   (SELECT id FROM workouts WHERE name = 'we check workout'),
+                   (SELECT id FROM exercises WHERE name = 'WE Check Bench'),
+                   4, ''
+               )
+               $$,
+               '23514',
+               NULL,
+               'an empty note is rejected'
        );
 
 SELECT * FROM finish();

--- a/shared/heart_models/CHANGELOG.md
+++ b/shared/heart_models/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.0
+
+- `WorkoutExercise` gains an optional `note` — a short, user-authored pin describing how the
+  exercise is performed (e.g. "do one hand at a time"), distinct from a comment. Round-trips through
+  `fromJson`/`toMap` and is carried forward by `Workout.copy()` (it's an instruction, not a
+  measurement like `met`). Additive; null when unset. The server caps it at 500 characters.
+
 ## 1.2.0
 
 - `GoalService.getTargetUserGoals` gains an optional `archived` flag: `false` (default) returns the

--- a/shared/heart_models/lib/src/models/workout.dart
+++ b/shared/heart_models/lib/src/models/workout.dart
@@ -26,6 +26,12 @@ abstract interface class WorkoutExercise
   /// sync and comparable across users. Null without wearable data.
   abstract double? met;
 
+  /// A short, user-authored pin describing how this exercise is performed — e.g.
+  /// "do one hand at a time". The owner's own inline description, edited as part
+  /// of the workout and distinct from a comment (which is social and threaded).
+  /// Null when unset; the server caps it at 500 characters.
+  abstract String? note;
+
   void add(ExerciseSet set);
 
   bool remove(ExerciseSet set);
@@ -54,6 +60,7 @@ abstract interface class WorkoutExercise
       id: json['id'],
       order: json['exercise_order'] ?? json['order'],
       met: (json['met'] as num?)?.toDouble(),
+      note: json['note'] as String?,
     );
   }
 }
@@ -197,12 +204,16 @@ class _WorkoutExercise with Iterable<ExerciseSet>, HasUuid implements WorkoutExe
   @override
   double? met;
 
+  @override
+  String? note;
+
   _WorkoutExercise._({
     ExerciseSet? starter,
     DateTime? start,
     required this.id,
     this.order,
     this.met,
+    this.note,
     required Exercise exercise,
     List<ExerciseSet>? sets,
   }) : _exercise = exercise,
@@ -253,6 +264,7 @@ class _WorkoutExercise with Iterable<ExerciseSet>, HasUuid implements WorkoutExe
       'exercise': ?firstOrNull?.exercise.toMap(),
       'start': start.toIso8601String(),
       'met': ?met,
+      'note': ?note,
       'sets': [
         for (final each in this) each.toMap(),
       ],
@@ -574,6 +586,9 @@ class _Workout with Iterable<WorkoutExercise>, HasUuid implements Workout {
         final exercise = WorkoutExercise(
           starter: each.first.copy(),
         );
+        // met/calories are measurements of the original session (dropped above);
+        // a note is an instruction on how to do the exercise, so a repeat carries it.
+        exercise.note = each.note;
 
         for (final (index, set) in each.skip(1).indexed) {
           final start = DateTime.timestamp().add(Duration(milliseconds: 2 * index));

--- a/shared/heart_models/pubspec.yaml
+++ b/shared/heart_models/pubspec.yaml
@@ -1,6 +1,6 @@
 name: heart_models
 description: "Interfaces and data classes"
-version: 1.2.0
+version: 1.3.0
 publish_to: none
 
 environment:

--- a/shared/heart_models/test/workout_test.dart
+++ b/shared/heart_models/test/workout_test.dart
@@ -318,6 +318,39 @@ void main() {
           expect(((map['sets'] as List).first as Map)['id'], starterSet.id);
         },
       );
+
+      test(
+        'toMap carries a note and omits it when unset',
+        () {
+          when(mockExercise.toMap()).thenReturn({'name': 'Mock Exercise'});
+
+          final withNote = WorkoutExercise(starter: starterSet)..note = 'do one hand at a time';
+          expect(withNote.toMap()['note'], 'do one hand at a time');
+
+          final without = WorkoutExercise(starter: starterSet);
+          expect(without.toMap().containsKey('note'), isFalse);
+        },
+      );
+
+      test(
+        'fromJson restores the note',
+        () {
+          final exercise = Exercise(
+            name: 'Bench',
+            category: Category.weightedBodyWeight,
+            target: Target.chest,
+          );
+          final parsed = WorkoutExercise.fromJson({
+            'id': 'we-1',
+            'exercise': exercise.toMap(),
+            'exercise_order': 0,
+            'note': 'pause at the bottom',
+            'sets': <Map>[],
+          });
+
+          expect(parsed.note, 'pause at the bottom');
+        },
+      );
     },
   );
 
@@ -539,6 +572,18 @@ void main() {
           final copy = workout.copy(sameId: true);
 
           expect(copy.id, equals(workout.id));
+        },
+      );
+
+      test(
+        'copy carries the exercise note forward',
+        () {
+          workoutExercise.note = 'do one hand at a time';
+          workout.append(workoutExercise);
+
+          final copy = workout.copy();
+
+          expect(copy.first.note, 'do one hand at a time');
         },
       );
 


### PR DESCRIPTION
### Description

This pull request adds an optional `note` field within the `WorkoutExercise` model and enables the addition of individualized notes for each exercise in workout sessions.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Additional context

This functionality enhances the flexibility of workout tracking by allowing users to include exercise-specific notes, such as tips, observations, or adjustments.