### PR TITLE
Add dev-only IAM role for autonomous coding agents

### DIFF
--- a/infrastructure/global/README.md
+++ b/infrastructure/global/README.md
@@ -2,6 +2,8 @@
 
 Account-tier resources — GitHub OIDC provider + the deploy role each account's workflows assume. Same shape as `infrastructure/app/`: a reusable `stack/` module plus per-account `environments/`. Each AWS account gets its own deploy of this stack.
 
+The dev environment additionally defines `heart-agent` (`environments/dev/agent.tf`) — a read-only role for autonomous coding agents, assumable only by the developer's dev-account IAM user. Dev-only by construction; its ARN goes in `AGENT_AWS_ROLE_ARN` in `~/.config/heart-agents/default.env` on the dev machine, never in a repo.
+
 ## Layout
 
 ```

--- a/infrastructure/global/environments/dev/agent.tf
+++ b/infrastructure/global/environments/dev/agent.tf
@@ -1,0 +1,40 @@
+# Role for autonomous coding agents. Deliberately defined here rather than in
+# the shared stack module: it is dev-only and must not exist in prod.
+#
+# The agent launcher on the dev machine assumes this role with the developer's
+# own `heart-dev` profile and injects the short-lived STS session credentials
+# into agent containers — no long-lived agent secret exists anywhere. The role
+# ARN is expected to land in AGENT_AWS_ROLE_ARN in
+# ~/.config/heart-agents/default.env on the dev machine, never in a repo.
+#
+# Read-only to start. When a task genuinely needs a write (redriving a dev
+# queue, invoking a dev Lambda), add a narrow inline policy naming those ARNs
+# then — nothing is pre-granted.
+
+data "aws_iam_policy_document" "agent_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::583168578067:user/Kit"]
+    }
+  }
+}
+
+resource "aws_iam_role" "agent" {
+  name               = "heart-agent"
+  assume_role_policy = data.aws_iam_policy_document.agent_trust.json
+  # the launcher requests 4h by default but may go longer for big tasks
+  max_session_duration = 43200
+}
+
+resource "aws_iam_role_policy_attachment" "agent_read_only" {
+  role       = aws_iam_role.agent.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+output "agent_role_arn" {
+  value = aws_iam_role.agent.arn
+}


### PR DESCRIPTION
## Description

### Summary of Changes
- Introduced a new IAM role intended for use by autonomous coding agents in development environments only.
- Ensured that the IAM role has necessary permissions specific to development tasks.

Closes #49
